### PR TITLE
Backtrack

### DIFF
--- a/backtrack.py
+++ b/backtrack.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 
 # Read case configuration
-with open("cases/era5_2013.yaml") as f:
+with open("cases/era5_2013_local.yaml") as f:
     config = yaml.safe_load(f)
 
 
@@ -31,7 +31,57 @@ def input_path(date):
 
 
 def output_path(date):
-    return f"{output_dir}/{date.strftime('%Y-%m-%d')}_Sa_track.nc"
+    return f"{output_dir}/{date.strftime('%Y-%m-%d')}_s_track.nc"
+
+
+def to_boundaries_zonal(fa_e, p):
+    """Define the horizontal fluxes over the east/west boundaries."""
+    fa_e_boundary = np.zeros_like(fa_e)
+    fa_e_boundary[:, :, :-1] = 0.5 * (fa_e[:, :, :-1] + fa_e[:, :, 1:])
+    if config["periodic_boundary"]:
+        fa_e_boundary[:, :, -1] = 0.5 * (fa_e[:, :, -1] + fa_e[:, :, 0])
+
+    # find out where the positive and negative fluxes are
+    fa_e_pos = np.ones_like(fa_e)
+    fa_e_neg = fa_e_pos - 1
+    fa_e_pos[fa_e_boundary < 0] = 0
+
+    # separate directions west-east (all positive numbers)
+    fa_e_we = fa_e_boundary * fa_e_pos
+    fa_e_ew = fa_e_boundary * fa_e_neg
+
+    # fluxes over the western boundary
+    fa_w_we = np.nan * np.zeros_like(p)
+    fa_w_ew = np.nan * np.zeros_like(p)
+    fa_w_we[:, :, 1:] = fa_e_we[:, :, :-1]
+    fa_w_we[:, :, 0] = fa_e_we[:, :, -1]
+    fa_w_ew[:, :, 1:] = fa_e_ew[:, :, :-1]
+    fa_w_ew[:, :, 0] = fa_e_ew[:, :, -1]
+
+    return fa_e_we, fa_e_ew, fa_w_we, fa_w_ew
+
+
+def to_boundaries_meridional(fa_n, p):
+    """Define the horizontal fluxes over the north/south boundaries."""
+    fa_n_boundary = np.zeros_like(fa_n)
+    fa_n_boundary[:, 1:, :] = 0.5 * (fa_n[:, :-1, :] + fa_n[:, 1:, :])
+
+    # find out where the positive and negative fluxes are
+    fa_n_pos = np.ones_like(fa_n)
+    fa_n_pos[fa_n_boundary < 0] = 0  # invalid value encountered in less
+    fa_n_neg = fa_n_pos - 1
+
+    # separate directions south-north (all positive numbers)
+    fa_n_sn = fa_n_boundary * fa_n_pos
+    fa_n_ns = fa_n_boundary * fa_n_neg
+
+    # fluxes over the southern boundary
+    fa_s_sn = np.nan * np.zeros_like(p)
+    fa_s_ns = np.nan * np.zeros_like(p)
+    fa_s_sn[:, :-1, :] = fa_n_sn[:, 1:, :]
+    fa_s_ns[:, :-1, :] = fa_n_ns[:, 1:, :]
+
+    return fa_n_sn, fa_n_ns, fa_s_sn, fa_s_ns
 
 
 def backtrack(
@@ -39,150 +89,74 @@ def backtrack(
     longitude,
     Kvf,
     region,
-    Fa_E_upper,
-    Fa_N_upper,
-    Fa_E_lower,
-    Fa_N_lower,
+    Fa_east_upper,
+    Fa_north_upper,
+    Fa_east_lower,
+    Fa_north_lower,
     Fa_Vert,
     E,
     P,
-    W_upper,
-    W_lower,
-    Sa_track_upper_last,
-    Sa_track_lower_last,
+    s_upper,
+    s_lower,
+    s_track_upper_last,
+    s_track_lower_last,
 ):
     P_region = region * P
 
     # Total moisture in the column
-    W = W_upper + W_lower
+    W = s_upper + s_lower
 
     # separate the direction of the vertical flux and make it absolute
     Fa_upward = np.zeros(np.shape(Fa_Vert))
-    Fa_upward[Fa_Vert <= 0] = Fa_Vert[
-        Fa_Vert <= 0
-    ]  # in 4th timestep: __main__:1: RuntimeWarning: invalid value encountered in less_equal # not a problem
+    Fa_upward[Fa_Vert <= 0] = Fa_Vert[Fa_Vert <= 0]
     Fa_downward = np.zeros(np.shape(Fa_Vert))
     Fa_downward[Fa_Vert >= 0] = Fa_Vert[Fa_Vert >= 0]
     Fa_upward = np.abs(Fa_upward)
 
     # include the vertical dispersion
-    if Kvf == 0:
-        pass
-        # do nothing
-    else:
+    if Kvf != 0:
         Fa_upward = (1.0 + Kvf) * Fa_upward
         Fa_upward[Fa_Vert >= 0] = Fa_Vert[Fa_Vert >= 0] * Kvf
         Fa_downward = (1.0 + Kvf) * Fa_downward
         Fa_downward[Fa_Vert <= 0] = np.abs(Fa_Vert[Fa_Vert <= 0]) * Kvf
 
-    # define the horizontal fluxes over the boundaries
-    # fluxes over the eastern boundary
-    Fa_E_upper_boundary = np.zeros(np.shape(Fa_E_upper))
-    Fa_E_upper_boundary[:, :, :-1] = 0.5 * (Fa_E_upper[:, :, :-1] + Fa_E_upper[:, :, 1:])
-    if config["periodic_boundary"]:
-        Fa_E_upper_boundary[:, :, -1] = 0.5 * (Fa_E_upper[:, :, -1] + Fa_E_upper[:, :, 0])
-    Fa_E_lower_boundary = np.zeros(np.shape(Fa_E_lower))
-    Fa_E_lower_boundary[:, :, :-1] = 0.5 * (Fa_E_lower[:, :, :-1] + Fa_E_lower[:, :, 1:])
-    if config["periodic_boundary"]:
-        Fa_E_lower_boundary[:, :, -1] = 0.5 * (Fa_E_lower[:, :, -1] + Fa_E_lower[:, :, 0])
-
-    # find out where the positive and negative fluxes are
-    Fa_E_upper_pos = np.ones(np.shape(Fa_E_upper))
-    Fa_E_lower_pos = np.ones(np.shape(Fa_E_lower))
-    Fa_E_upper_pos[Fa_E_upper_boundary < 0] = 0
-    Fa_E_lower_pos[Fa_E_lower_boundary < 0] = 0
-    Fa_E_upper_neg = Fa_E_upper_pos - 1
-    Fa_E_lower_neg = Fa_E_lower_pos - 1
-
-    # separate directions west-east (all positive numbers)
-    Fa_E_upper_WE = Fa_E_upper_boundary * Fa_E_upper_pos
-    Fa_E_upper_EW = Fa_E_upper_boundary * Fa_E_upper_neg
-    Fa_E_lower_WE = Fa_E_lower_boundary * Fa_E_lower_pos
-    Fa_E_lower_EW = Fa_E_lower_boundary * Fa_E_lower_neg
-
-    # fluxes over the western boundary
-    Fa_W_upper_WE = np.nan * np.zeros(np.shape(P))
-    Fa_W_upper_WE[:, :, 1:] = Fa_E_upper_WE[:, :, :-1]
-    Fa_W_upper_WE[:, :, 0] = Fa_E_upper_WE[:, :, -1]
-    Fa_W_upper_EW = np.nan * np.zeros(np.shape(P))
-    Fa_W_upper_EW[:, :, 1:] = Fa_E_upper_EW[:, :, :-1]
-    Fa_W_upper_EW[:, :, 0] = Fa_E_upper_EW[:, :, -1]
-    Fa_W_lower_WE = np.nan * np.zeros(np.shape(P))
-    Fa_W_lower_WE[:, :, 1:] = Fa_E_lower_WE[:, :, :-1]
-    Fa_W_lower_WE[:, :, 0] = Fa_E_lower_WE[:, :, -1]
-    Fa_W_lower_EW = np.nan * np.zeros(np.shape(P))
-    Fa_W_lower_EW[:, :, 1:] = Fa_E_lower_EW[:, :, :-1]
-    Fa_W_lower_EW[:, :, 0] = Fa_E_lower_EW[:, :, -1]
-
-    # fluxes over the northern boundary
-    # Imme: why do you multiply here your zeros with nans ?!?!?!? you do not do that for Fa_E_upper_boundary
-    # Fa_N_upper_boundary = np.nan*np.zeros(np.shape(Fa_N_upper));
-    # Adapted by Imme
-    Fa_N_upper_boundary = np.zeros(np.shape(Fa_N_upper))
-    # Imme: why do you multiply here your zeros with nans ?!?!?!? you do not do that for Fa_E_upper_boundary
-    Fa_N_upper_boundary[:, 1:, :] = 0.5 * (Fa_N_upper[:, :-1, :] + Fa_N_upper[:, 1:, :])
-    # Fa_N_lower_boundary = np.nan*np.zeros(np.shape(Fa_N_lower));
-    # Adapted by Imme
-    Fa_N_lower_boundary = np.zeros(np.shape(Fa_N_lower))
-    # als je niet met np.nan multiplied krijg je in de volgende alinea geen invalid value encountered in less
-    # verandert er verder nog wat!??!
-    Fa_N_lower_boundary[:, 1:, :] = 0.5 * (Fa_N_lower[:, :-1, :] + Fa_N_lower[:, 1:, :])
-
-    # find out where the positive and negative fluxes are
-    Fa_N_upper_pos = np.ones(np.shape(Fa_N_upper))
-    Fa_N_lower_pos = np.ones(np.shape(Fa_N_lower))
-    Fa_N_upper_pos[Fa_N_upper_boundary < 0] = 0  # Invalid value encountered in less
-    Fa_N_lower_pos[Fa_N_lower_boundary < 0] = 0  # Invalid value encountered in less
-    Fa_N_upper_neg = Fa_N_upper_pos - 1
-    Fa_N_lower_neg = Fa_N_lower_pos - 1
-
-    # separate directions south-north (all positive numbers)
-    Fa_N_upper_SN = Fa_N_upper_boundary * Fa_N_upper_pos
-    Fa_N_upper_NS = Fa_N_upper_boundary * Fa_N_upper_neg
-    Fa_N_lower_SN = Fa_N_lower_boundary * Fa_N_lower_pos
-    Fa_N_lower_NS = Fa_N_lower_boundary * Fa_N_lower_neg
-
-    # fluxes over the southern boundary
-    Fa_S_upper_SN = np.nan * np.zeros(np.shape(P))
-    Fa_S_upper_SN[:, :-1, :] = Fa_N_upper_SN[:, 1:, :]
-    Fa_S_upper_NS = np.nan * np.zeros(np.shape(P))
-    Fa_S_upper_NS[:, :-1, :] = Fa_N_upper_NS[:, 1:, :]
-    Fa_S_lower_SN = np.nan * np.zeros(np.shape(P))
-    Fa_S_lower_SN[:, :-1, :] = Fa_N_lower_SN[:, 1:, :]
-    Fa_S_lower_NS = np.nan * np.zeros(np.shape(P))
-    Fa_S_lower_NS[:, :-1, :] = Fa_N_lower_NS[:, 1:, :]
+    # Define the horizontal fluxes over the boundaries
+    Fa_east_upper_WE, Fa_east_upper_EW, Fa_west_upper_WE, Fa_west_upper_EW = to_boundaries_zonal(Fa_east_upper, P)
+    Fa_east_lower_WE, Fa_east_lower_EW, Fa_west_lower_WE, Fa_west_lower_EW = to_boundaries_zonal(Fa_east_lower, P)
+    Fa_north_upper_SN, Fa_north_upper_NS, Fa_south_upper_SN, Fa_south_upper_NS = to_boundaries_meridional(Fa_north_upper, P)
+    Fa_north_lower_SN, Fa_north_lower_NS, Fa_south_lower_SN, Fa_south_lower_NS = to_boundaries_meridional(Fa_north_lower, P)
 
     # defining size of output
-    Sa_track_lower = np.zeros(np.shape(W_lower))
-    Sa_track_upper = np.zeros(np.shape(W_upper))
+    s_track_lower = np.zeros_like(s_lower)
+    s_track_upper = np.zeros_like(s_upper)
 
     # assign begin values of output == last (but first index) values of the previous time slot
-    Sa_track_lower[-1, :, :] = Sa_track_lower_last
-    Sa_track_upper[-1, :, :] = Sa_track_upper_last
+    s_track_lower[-1, :, :] = s_track_lower_last
+    s_track_upper[-1, :, :] = s_track_upper_last
 
     # defining sizes of tracked moisture
-    Sa_track_after_Fa_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_track_after_Fa_P_E_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_track_E_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_track_W_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_track_N_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_track_S_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_track_after_Fa_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_track_after_Fa_P_E_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_track_E_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_track_W_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_track_N_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_track_S_upper = np.zeros(np.shape(Sa_track_upper_last))
+    s_track_after_Fa_lower = np.zeros_like(s_track_lower_last)
+    s_track_after_Fa_P_east_lower = np.zeros_like(s_track_lower_last)
+    s_track_east_lower = np.zeros_like(s_track_lower_last)
+    s_track_west_lower = np.zeros_like(s_track_lower_last)
+    s_track_north_lower = np.zeros_like(s_track_lower_last)
+    s_track_south_lower = np.zeros_like(s_track_lower_last)
+    s_track_after_Fa_upper = np.zeros_like(s_track_upper_last)
+    s_track_after_Fa_P_east_upper = np.zeros_like(s_track_upper_last)
+    s_track_east_upper = np.zeros_like(s_track_upper_last)
+    s_track_west_upper = np.zeros_like(s_track_upper_last)
+    s_track_north_upper = np.zeros_like(s_track_upper_last)
+    s_track_south_upper = np.zeros_like(s_track_upper_last)
 
     # define sizes of total moisture
-    Sa_E_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_W_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_N_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_S_lower = np.zeros(np.shape(Sa_track_lower_last))
-    Sa_E_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_W_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_N_upper = np.zeros(np.shape(Sa_track_upper_last))
-    Sa_S_upper = np.zeros(np.shape(Sa_track_upper_last))
+    s_east_lower = np.zeros_like(s_track_lower_last)
+    s_west_lower = np.zeros_like(s_track_lower_last)
+    s_north_lower = np.zeros_like(s_track_lower_last)
+    s_south_lower = np.zeros_like(s_track_lower_last)
+    s_east_upper = np.zeros_like(s_track_upper_last)
+    s_west_upper = np.zeros_like(s_track_upper_last)
+    s_north_upper = np.zeros_like(s_track_upper_last)
+    s_south_upper = np.zeros_like(s_track_upper_last)
 
     # define variables that find out what happens to the water
     ntime = w_upper.shape[0]
@@ -190,164 +164,106 @@ def backtrack(
     south_loss = np.zeros((ntime, 1, len(longitude)))
     east_loss = np.zeros((ntime, 1, len(latitude)))
     west_loss = np.zeros((ntime, 1, len(latitude)))
-    down_to_upper = np.zeros(np.shape(P))
-    top_to_lower = np.zeros(np.shape(P))
-    water_lost = np.zeros(np.shape(P))
+    down_to_upper = np.zeros_like(P)
+    top_to_lower = np.zeros_like(P)
+    water_lost = np.zeros_like(P)
 
     # Sa calculation backward in time
-    for t in np.arange(ntime-1, 0, -1):
-
-        # Upper layer: define values of total moisture
-        Sa_N_lower[0, 1:, :] = W_lower[t, 0:-1, :]
-        Sa_S_lower[0, :-1, :] = W_lower[t, 1:, :]
-        Sa_E_lower[0, :, :-1] = W_lower[t, :, 1:]
-        Sa_W_lower[0, :, 1:] = W_lower[t, :, :-1]
-        # TODO: fix div by zero issue for periodic_boundary
-        # Sa_E_lower[0,:,-1] = W_lower[t,:,0]
-        # Sa_W_lower[0,:,0] = W_lower[t,:,-1]
+    for t in reversed(range(ntime)):
 
         # Lower layer: define values of total moisture
-        Sa_N_upper[0, 1:, :] = W_upper[t, :-1, :]
-        Sa_S_upper[0, :-1, :] = W_upper[t, 1:, :]
-        Sa_E_upper[0, :, :-1] = W_upper[t, :, 1:]
-        Sa_W_upper[0, :, 1:] = W_upper[t, :, :-1]
+        s_north_lower[0, 1:, :] = s_lower[t, :-1, :]
+        s_south_lower[0, :-1, :] = s_lower[t, 1:, :]
+        s_east_lower[0, :, :-1] = s_lower[t, :, 1:]
+        s_west_lower[0, :, 1:] = s_lower[t, :, :-1]
         # TODO: fix div by zero issue for periodic_boundary
-        # Sa_E_upper[0,:,-1] = W_upper[t,:,0]
-        # Sa_W_upper[0,:,0] = W_upper[t,:,-1]
+        # s_east_lower[0,:,-1] = s_lower[t,:,0]
+        # s_west_lower[0,:,0] = s_lower[t,:,-1]
 
         # Lower layer: define values of tracked moisture of neighbouring grid cells
-        Sa_track_N_lower[0, 1:, :] = Sa_track_lower[t, :-1, :]
-        Sa_track_S_lower[0, :-1, :] = Sa_track_lower[t, 1:, :]
-        Sa_track_E_lower[0, :, :-1] = Sa_track_lower[t, :, 1:]
-        Sa_track_W_lower[0, :, 1:] = Sa_track_lower[t, :, :-1]
+        s_track_north_lower[0, 1:, :] = s_track_lower[t, :-1, :]
+        s_track_south_lower[0, :-1, :] = s_track_lower[t, 1:, :]
+        s_track_east_lower[0, :, :-1] = s_track_lower[t, :, 1:]
+        s_track_west_lower[0, :, 1:] = s_track_lower[t, :, :-1]
         if config["periodic_boundary"]:
-            Sa_track_E_lower[0, :, -1] = Sa_track_lower[t, :, 0]
-            Sa_track_W_lower[0, :, 0] = Sa_track_lower[t, :, -1]
+            s_track_east_lower[0, :, -1] = s_track_lower[t, :, 0]
+            s_track_west_lower[0, :, 0] = s_track_lower[t, :, -1]
 
-        # down: calculate with moisture fluxes
-        Sa_track_after_Fa_lower[0, 1:-1, 1:-1] = (
-            Sa_track_lower[t, 1:-1, 1:-1]
-            + Fa_E_lower_WE[t - 1, 1:-1, 1:-1]
-            * (Sa_track_E_lower[0, 1:-1, 1:-1] / Sa_E_lower[0, 1:-1, 1:-1])
-            - Fa_E_lower_EW[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
-            - Fa_W_lower_WE[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
-            + Fa_W_lower_EW[t - 1, 1:-1, 1:-1]
-            * (Sa_track_W_lower[0, 1:-1, 1:-1] / Sa_W_lower[0, 1:-1, 1:-1])
-            + Fa_N_lower_SN[t - 1, 1:-1, 1:-1]
-            * (Sa_track_N_lower[0, 1:-1, 1:-1] / Sa_N_lower[0, 1:-1, 1:-1])
-            - Fa_N_lower_NS[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
-            - Fa_S_lower_SN[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
-            + Fa_S_lower_NS[t - 1, 1:-1, 1:-1]
-            * (Sa_track_S_lower[0, 1:-1, 1:-1] / Sa_S_lower[0, 1:-1, 1:-1])
-            - Fa_downward[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
-            + Fa_upward[t - 1, 1:-1, 1:-1]
-            * (Sa_track_upper[t, 1:-1, 1:-1] / W_upper[t, 1:-1, 1:-1])
+        # Lower layer: calculate with moisture fluxes
+        s_track_after_Fa_lower[0, 1:-1, 1:-1] = (
+            s_track_lower[t, 1:-1, 1:-1]
+            + Fa_east_lower_WE[t - 1, 1:-1, 1:-1] * (s_track_east_lower[0, 1:-1, 1:-1] / s_east_lower[0, 1:-1, 1:-1])
+            - Fa_east_lower_EW[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
+            - Fa_west_lower_WE[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
+            + Fa_west_lower_EW[t - 1, 1:-1, 1:-1] * (s_track_west_lower[0, 1:-1, 1:-1] / s_west_lower[0, 1:-1, 1:-1])
+            + Fa_north_lower_SN[t - 1, 1:-1, 1:-1] * (s_track_north_lower[0, 1:-1, 1:-1] / s_north_lower[0, 1:-1, 1:-1])
+            - Fa_north_lower_NS[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
+            - Fa_south_lower_SN[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
+            + Fa_south_lower_NS[t - 1, 1:-1, 1:-1] * (s_track_south_lower[0, 1:-1, 1:-1] / s_south_lower[0, 1:-1, 1:-1])
+            - Fa_downward[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
+            + Fa_upward[t - 1, 1:-1, 1:-1] * (s_track_upper[t, 1:-1, 1:-1] / s_upper[t, 1:-1, 1:-1])
         )
 
-        # top: define values of tracked moisture of neighbouring grid cells
-        Sa_track_N_upper[0, 1:, :] = Sa_track_upper[t, :-1, :]
-        Sa_track_S_upper[0, :-1, :] = Sa_track_upper[t, 1:, :]
-        Sa_track_E_upper[0, :, :-1] = Sa_track_upper[t, :, 1:]
-        Sa_track_W_upper[0, :, 1:] = Sa_track_upper[t, :, :-1]
-        if config["periodic_boundary"]:
-            Sa_track_E_upper[0, :, -1] = Sa_track_upper[t, :, 0]
-            Sa_track_W_upper[0, :, 0] = Sa_track_upper[t, :, -1]
+        # Upper layer: define values of total moisture
+        s_north_upper[0, 1:, :] = s_upper[t, :-1, :]
+        s_south_upper[0, :-1, :] = s_upper[t, 1:, :]
+        s_east_upper[0, :, :-1] = s_upper[t, :, 1:]
+        s_west_upper[0, :, 1:] = s_upper[t, :, :-1]
+        # TODO: fix div by zero issue for periodic_boundary
+        # s_east_upper[0,:,-1] = s_upper[t,:,0]
+        # s_west_upper[0,:,0] = s_upper[t,:,-1]
 
+        # Upper layer: define values of tracked moisture of neighbouring grid cells
+        s_track_north_upper[0, 1:, :] = s_track_upper[t, :-1, :]
+        s_track_south_upper[0, :-1, :] = s_track_upper[t, 1:, :]
+        s_track_east_upper[0, :, :-1] = s_track_upper[t, :, 1:]
+        s_track_west_upper[0, :, 1:] = s_track_upper[t, :, :-1]
+        if config["periodic_boundary"]:
+            s_track_east_upper[0, :, -1] = s_track_upper[t, :, 0]
+            s_track_west_upper[0, :, 0] = s_track_upper[t, :, -1]
 
         # top: calculate with moisture fluxes
-        Sa_track_after_Fa_upper[0, 1:-1, 1:-1] = (
-            Sa_track_upper[t, 1:-1, 1:-1]
-            + Fa_E_upper_WE[t - 1, 1:-1, 1:-1]
-            * (Sa_track_E_upper[0, 1:-1, 1:-1] / Sa_E_upper[0, 1:-1, 1:-1])
-            - Fa_E_upper_EW[t - 1, 1:-1, 1:-1]
-            * (Sa_track_upper[t, 1:-1, 1:-1] / W_upper[t, 1:-1, 1:-1])
-            - Fa_W_upper_WE[t - 1, 1:-1, 1:-1]
-            * (Sa_track_upper[t, 1:-1, 1:-1] / W_upper[t, 1:-1, 1:-1])
-            + Fa_W_upper_EW[t - 1, 1:-1, 1:-1]
-            * (Sa_track_W_upper[0, 1:-1, 1:-1] / Sa_W_upper[0, 1:-1, 1:-1])
-            + Fa_N_upper_SN[t - 1, 1:-1, 1:-1]
-            * (Sa_track_N_upper[0, 1:-1, 1:-1] / Sa_N_upper[0, 1:-1, 1:-1])
-            - Fa_N_upper_NS[t - 1, 1:-1, 1:-1]
-            * (Sa_track_upper[t, 1:-1, 1:-1] / W_upper[t, 1:-1, 1:-1])
-            - Fa_S_upper_SN[t - 1, 1:-1, 1:-1]
-            * (Sa_track_upper[t, 1:-1, 1:-1] / W_upper[t, 1:-1, 1:-1])
-            + Fa_S_upper_NS[t - 1, 1:-1, 1:-1]
-            * (Sa_track_S_upper[0, 1:-1, 1:-1] / Sa_S_upper[0, 1:-1, 1:-1])
-            + Fa_downward[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
-            - Fa_upward[t - 1, 1:-1, 1:-1]
-            * (Sa_track_upper[t, 1:-1, 1:-1] / W_upper[t, 1:-1, 1:-1])
+        s_track_after_Fa_upper[0, 1:-1, 1:-1] = (
+            s_track_upper[t, 1:-1, 1:-1]
+            + Fa_east_upper_WE[t - 1, 1:-1, 1:-1] * (s_track_east_upper[0, 1:-1, 1:-1] / s_east_upper[0, 1:-1, 1:-1])
+            - Fa_east_upper_EW[t - 1, 1:-1, 1:-1] * (s_track_upper[t, 1:-1, 1:-1] / s_upper[t, 1:-1, 1:-1])
+            - Fa_west_upper_WE[t - 1, 1:-1, 1:-1] * (s_track_upper[t, 1:-1, 1:-1] / s_upper[t, 1:-1, 1:-1])
+            + Fa_west_upper_EW[t - 1, 1:-1, 1:-1] * (s_track_west_upper[0, 1:-1, 1:-1] / s_west_upper[0, 1:-1, 1:-1])
+            + Fa_north_upper_SN[t - 1, 1:-1, 1:-1] * (s_track_north_upper[0, 1:-1, 1:-1] / s_north_upper[0, 1:-1, 1:-1])
+            - Fa_north_upper_NS[t - 1, 1:-1, 1:-1] * (s_track_upper[t, 1:-1, 1:-1] / s_upper[t, 1:-1, 1:-1])
+            - Fa_south_upper_SN[t - 1, 1:-1, 1:-1] * (s_track_upper[t, 1:-1, 1:-1] / s_upper[t, 1:-1, 1:-1])
+            + Fa_south_upper_NS[t - 1, 1:-1, 1:-1] * (s_track_south_upper[0, 1:-1, 1:-1] / s_south_upper[0, 1:-1, 1:-1])
+            + Fa_downward[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
+            - Fa_upward[t - 1, 1:-1, 1:-1] * (s_track_upper[t, 1:-1, 1:-1] / s_upper[t, 1:-1, 1:-1])
         )
 
         # losses to the north and south
-        north_loss[t - 1, 0, :] = Fa_N_upper_NS[t - 1, 1, :] * (
-            Sa_track_upper[t, 1, :] / W_upper[t, 1, :]
-        ) + Fa_N_lower_NS[t - 1, 1, :] * (Sa_track_lower[t, 1, :] / W_lower[t, 1, :])
-        south_loss[t - 1, 0, :] = Fa_S_upper_SN[t - 1, -2, :] * (
-            Sa_track_upper[t, -2, :] / W_upper[t, -2, :]
-        ) + Fa_S_lower_SN[t - 1, -2, :] * (Sa_track_lower[t, -2, :] / W_lower[t, -2, :])
+        north_loss[t - 1, 0, :] = Fa_north_upper_NS[t - 1, 1, :] * (s_track_upper[t, 1, :] / s_upper[t, 1, :]) + Fa_north_lower_NS[t - 1, 1, :] * (s_track_lower[t, 1, :] / s_lower[t, 1, :])
+        south_loss[t - 1, 0, :] = Fa_south_upper_SN[t - 1, -2, :] * (s_track_upper[t, -2, :] / s_upper[t, -2, :]) + Fa_south_lower_SN[t - 1, -2, :] * (s_track_lower[t, -2, :] / s_lower[t, -2, :])
 
-        # Imme added: losses to the east and west
-        east_loss[t - 1, 0, :] = Fa_E_upper_EW[t - 1, :, -2] * (
-            Sa_track_upper[t, :, -2] / W_upper[t, :, -2]
-        ) + Fa_E_lower_EW[t - 1, :, -2] * (Sa_track_lower[t, :, -2] / W_lower[t, :, -2])
-        west_loss[t - 1, 0, :] = Fa_W_upper_WE[t - 1, :, 1] * (
-            Sa_track_upper[t, :, 1] / W_upper[t, :, 1]
-        ) + Fa_W_lower_WE[t - 1, :, 1] * (Sa_track_lower[t, :, 1] / W_lower[t, :, 1])
+        # losses to the east and west
+        east_loss[t - 1, 0, :] = Fa_east_upper_EW[t - 1, :, -2] * (s_track_upper[t, :, -2] / s_upper[t, :, -2]) + Fa_east_lower_EW[t - 1, :, -2] * (s_track_lower[t, :, -2] / s_lower[t, :, -2])
+        west_loss[t - 1, 0, :] = Fa_west_upper_WE[t - 1, :, 1] * (s_track_upper[t, :, 1] / s_upper[t, :, 1]) + Fa_west_lower_WE[t - 1, :, 1] * (s_track_lower[t, :, 1] / s_lower[t, :, 1])
 
         # down: add precipitation and subtract evaporation
-        Sa_track_after_Fa_P_E_lower[0, 1:-1, 1:-1] = (
-            Sa_track_after_Fa_lower[0, 1:-1, 1:-1]
-            + P_region[t - 1, 1:-1, 1:-1] * (W_lower[t, 1:-1, 1:-1] / W[t, 1:-1, 1:-1])
-            - E[t - 1, 1:-1, 1:-1]
-            * (Sa_track_lower[t, 1:-1, 1:-1] / W_lower[t, 1:-1, 1:-1])
+        s_track_after_Fa_P_east_lower[0, 1:-1, 1:-1] = (
+            s_track_after_Fa_lower[0, 1:-1, 1:-1]
+            + P_region[t - 1, 1:-1, 1:-1] * (s_lower[t, 1:-1, 1:-1] / W[t, 1:-1, 1:-1])
+            - E[t - 1, 1:-1, 1:-1] * (s_track_lower[t, 1:-1, 1:-1] / s_lower[t, 1:-1, 1:-1])
         )
 
         # top: add precipitation
-        Sa_track_after_Fa_P_E_upper[0, 1:-1, 1:-1] = Sa_track_after_Fa_upper[
-            0, 1:-1, 1:-1
-        ] + P_region[t - 1, 1:-1, 1:-1] * (W_upper[t, 1:-1, 1:-1] / W[t, 1:-1, 1:-1])
+        s_track_after_Fa_P_east_upper[0, 1:-1, 1:-1] = s_track_after_Fa_upper[0, 1:-1, 1:-1] + P_region[t - 1, 1:-1, 1:-1] * (s_upper[t, 1:-1, 1:-1] / W[t, 1:-1, 1:-1])
 
         # down and top: redistribute unaccounted water that is otherwise lost from the sytem
-        down_to_upper[t - 1, :, :] = np.reshape(
-            np.maximum(
-                0,
-                np.reshape(
-                    Sa_track_after_Fa_P_E_lower, (np.size(Sa_track_after_Fa_P_E_lower))
-                )
-                - np.reshape(W_lower[t - 1, :, :], (np.size(W_lower[t - 1, :, :]))),
-            ),
-            (len(latitude), len(longitude)),
-        )  # Imme: invalid value encountered in maximum
-        top_to_lower[t - 1, :, :] = np.reshape(
-            np.maximum(
-                0,
-                np.reshape(
-                    Sa_track_after_Fa_P_E_upper, (np.size(Sa_track_after_Fa_P_E_upper))
-                )
-                - np.reshape(W_upper[t - 1, :, :], (np.size(W_upper[t - 1, :, :]))),
-            ),
-            (len(latitude), len(longitude)),
-        )  # Imme: invalid value encountered in maximum
-        Sa_track_lower[t - 1, 1:-1, 1:-1] = (
-            Sa_track_after_Fa_P_E_lower[0, 1:-1, 1:-1]
-            - down_to_upper[t - 1, 1:-1, 1:-1]
-            + top_to_lower[t - 1, 1:-1, 1:-1]
-        )
-        Sa_track_upper[t - 1, 1:-1, 1:-1] = (
-            Sa_track_after_Fa_P_E_upper[0, 1:-1, 1:-1]
-            - top_to_lower[t - 1, 1:-1, 1:-1]
-            + down_to_upper[t - 1, 1:-1, 1:-1]
-        )
+        down_to_upper[t - 1, :, :] = np.reshape(np.maximum(0, np.reshape(s_track_after_Fa_P_east_lower, (np.size(s_track_after_Fa_P_east_lower))) - np.reshape(s_lower[t - 1, :, :], (np.size(s_lower[t - 1, :, :]))),),(len(latitude), len(longitude)),)  # Imme: invalid value encountered in maximum
+        top_to_lower[t - 1, :, :] = np.reshape(np.maximum(0, np.reshape(s_track_after_Fa_P_east_upper, (np.size(s_track_after_Fa_P_east_upper))) - np.reshape(s_upper[t - 1, :, :], (np.size(s_upper[t - 1, :, :]))),),(len(latitude), len(longitude)),)  # Imme: invalid value encountered in maximum
+        s_track_lower[t - 1, 1:-1, 1:-1] = (s_track_after_Fa_P_east_lower[0, 1:-1, 1:-1] - down_to_upper[t - 1, 1:-1, 1:-1] + top_to_lower[t - 1, 1:-1, 1:-1])
+        s_track_upper[t - 1, 1:-1, 1:-1] = (s_track_after_Fa_P_east_upper[0, 1:-1, 1:-1] - top_to_lower[t - 1, 1:-1, 1:-1] + down_to_upper[t - 1, 1:-1, 1:-1])
 
     return (
-        Sa_track_upper,
-        Sa_track_lower,
+        s_track_upper,
+        s_track_lower,
         north_loss,
         south_loss,
         east_loss,

--- a/backtrack.py
+++ b/backtrack.py
@@ -137,8 +137,8 @@ def backtrack(
     # Allocate arrays for daily accumulations
     ntime, nlat, nlon = s_upper.shape
 
-    s_track_upper_sum = np.zeros((nlat, nlon))
-    s_track_lower_sum = np.zeros((nlat, nlon))
+    s_track_upper_mean = np.zeros((nlat, nlon))
+    s_track_lower_mean = np.zeros((nlat, nlon))
     e_track = np.zeros((nlat, nlon))
 
     north_loss = south_loss = np.zeros(nlon)
@@ -217,16 +217,16 @@ def backtrack(
                       + fx_w_lower_we * s_track_relative_lower)[:, 1]
 
         # Aggregate daily accumulations for calculating the daily means
-        s_track_lower_sum += s_track_lower
-        s_track_upper_sum += s_track_upper
+        s_track_lower_mean += s_track_lower / ntime
+        s_track_upper_mean += s_track_upper / ntime
 
     # Pack processed data into new dataset
     ds = xr.Dataset(
         {
             "s_track_upper_restart": (["lat", "lon"], s_track_upper),  # Keep last state for a restart
             "s_track_lower_restart": (["lat", "lon"], s_track_lower),
-            "s_track_upper": (["lat", "lon"], s_track_upper_sum / ntime),
-            "s_track_lower": (["lat", "lon"], s_track_upper_sum / ntime),
+            "s_track_upper": (["lat", "lon"], s_track_upper_mean),
+            "s_track_lower": (["lat", "lon"], s_track_upper_mean),
             "e_track": (["lat", "lon"], e_track),
             "north_loss": (["lon"], north_loss),
             "south_loss": (["lon"], south_loss),

--- a/backtrack.py
+++ b/backtrack.py
@@ -1,4 +1,3 @@
-from optparse import Values
 import yaml
 import xarray as xr
 
@@ -165,23 +164,20 @@ def backtrack(
         s_track_relative_upper = s_track_upper / s_upper[t]
         inner = np.s_[1:-1, 1:-1]
 
-        # Actual tracking
+        # Actual tracking (note: backtracking, all terms have been negated)
         s_track_lower[inner] += (
-            # TODO: Looks like I'm messing up my interpretation of incoming/outgoing here...
-            # e.g. I think fx_e_we should be an outgoing flux, but I'm not sure.
-            # Similarly, shouldn't upward be a loss term, and scaled with self instead of upper?
-            + fx_e_lower_we * shift_east(s_track_relative_lower)  # in from the east
-            + fx_w_lower_ew * shift_west(s_track_relative_lower)  # in from the west
-            + fy_n_lower_sn * shift_north(s_track_relative_lower)  # in from the north
-            + fy_s_lower_ns * shift_south(s_track_relative_lower)  # in from the south
-            + f_upward * s_track_relative_upper  # in from upper layer
-            - f_downward * s_track_relative_lower  # out to the upper layer
-            - fy_s_lower_sn * s_track_relative_lower  # out to the south
-            - fy_n_lower_ns * s_track_relative_lower  # out to the north
-            - fx_e_lower_ew * s_track_relative_lower  # out to the west
-            - fx_w_lower_we * s_track_relative_lower  # out to the east
-            + P_region * (s_lower[t] / s_total)  # gained from precipitation?
-            - evap[t-1] * s_track_relative_lower  # lost to evaporation?
+            + fx_e_lower_we * shift_east(s_track_relative_lower)
+            + fx_w_lower_ew * shift_west(s_track_relative_lower)
+            + fy_n_lower_sn * shift_north(s_track_relative_lower)
+            + fy_s_lower_ns * shift_south(s_track_relative_lower)
+            + f_upward * s_track_relative_upper
+            - f_downward * s_track_relative_lower
+            - fy_s_lower_sn * s_track_relative_lower
+            - fy_n_lower_ns * s_track_relative_lower
+            - fx_e_lower_ew * s_track_relative_lower
+            - fx_w_lower_we * s_track_relative_lower
+            + P_region * (s_lower[t] / s_total)
+            - evap[t-1] * s_track_relative_lower
         )[inner]
 
         s_track_upper[inner] += (

--- a/backtrack.py
+++ b/backtrack.py
@@ -226,7 +226,7 @@ def backtrack(
             "s_track_upper_restart": (["lat", "lon"], s_track_upper),  # Keep last state for a restart
             "s_track_lower_restart": (["lat", "lon"], s_track_lower),
             "s_track_upper": (["lat", "lon"], s_track_upper_mean),
-            "s_track_lower": (["lat", "lon"], s_track_upper_mean),
+            "s_track_lower": (["lat", "lon"], s_track_lower_mean),
             "e_track": (["lat", "lon"], e_track),
             "north_loss": (["lon"], north_loss),
             "south_loss": (["lon"], south_loss),

--- a/backtrack.py
+++ b/backtrack.py
@@ -195,8 +195,8 @@ def backtrack(
         )[inner]
 
         # down and top: redistribute unaccounted water that is otherwise lost from the sytem
-        lower_to_upper = np.maximum(0, s_track_lower) - s_lower[t - 1]
-        upper_to_lower = np.maximum(0, s_track_upper) - s_upper[t - 1]
+        lower_to_upper = np.maximum(0, s_track_lower - s_lower[t - 1])
+        upper_to_lower = np.maximum(0, s_track_upper - s_upper[t - 1])
         s_track_lower[inner] = (s_track_lower - lower_to_upper + upper_to_lower)[inner]
         s_track_upper[inner] = (s_track_upper - upper_to_lower + lower_to_upper)[inner]
 

--- a/cases/era5_2013.yaml
+++ b/cases/era5_2013.yaml
@@ -16,7 +16,7 @@ track_end_date: '20130604' #YYYYMMDD
 # Settings needed for the tracking run
 name_of_run: 'default_run'
 output_folder: ~/output_data
-veryfirstrun: true # true: starts from zero tracked water, false: loads tracked water
+restart: false # False: loads tracked water from previous run. True: starts from zero tracked water
 kvf: 3 # Vertical transport parameter for gross vertical transport between the layers during the tracking: "actual exchange = Kvf * F_vertical + F_vertical" in one direction and "-1 * (Kvf * F_vertical)" in opposite direction. # Default = 3.
 timetracking: false
 distancetracking: false


### PR DESCRIPTION
This PR further refactors the code for backtracking. The whole sample case now runs on my laptop in under 10 seconds. Some of the important changes are:

* Abbreviate commonly used code (e.g. `shift_east(...)`, `[inner]` and `s_track_relative`)
* Remove as many as possible empty array allocations
* Do the daily accumulations "on the fly", i.e. don't store intermediate values (3d) and then sum them, but just add them directly to a single (2d) output array.
* Compute intermediate variables (e.g. fx_e_lower_we) only one time step at a time. That saves a lot of working memory.

Please review thoroughly to identify any mistakes I might have made.