### PR TITLE
Add cumulative output figure

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ We recommend to create an editable installation in a dedicated conda environment
 
 ```
 # Create a dedicated conda environment
-conda create -n wam2layers -c conda-forge python=3.9 jupyterlab cartopy matplotlib
+conda create -n wam2layers -c conda-forge python=3.9 jupyterlab cartopy matplotlib cmocean
 conda activate wam2layers
 
 # Clone the source code repository

--- a/src/wam2layers/analysis/visualization.py
+++ b/src/wam2layers/analysis/visualization.py
@@ -192,5 +192,13 @@ def both(config_file):
     """Visualize both input and output data for experiment."""
     visualize_both(config_file)
 
+
+@cli.command()
+@click.argument('config_file', type=click.Path(exists=True))
+def snapshots(config_file):
+    """Visualize input and output snapshots for experiment."""
+    visualize_snapshots(config_file)
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
This PR adds the figure from the notebook in #119 under the command

`wam2layers visualize output cases/era5_2021.yaml` (or any other case)

![image](https://user-images.githubusercontent.com/17080502/188480360-a96ee13a-3737-4778-805f-b4349349595e.png)
