### PR TITLE
Implement simple moisture conservation check

### DIFF
--- a/cases/era5_2013.yaml
+++ b/cases/era5_2013.yaml
@@ -22,6 +22,7 @@ restart: false
 kvf: 3
 timetracking: false
 distancetracking: false
+log_level: low
 
 event_start_date: '20130603'
 event_end_date: '20130604'

--- a/cases/era5_2021.yaml
+++ b/cases/era5_2021.yaml
@@ -22,6 +22,7 @@ restart: false
 kvf: 3
 timetracking: false
 distancetracking: false
+log_level: low
 
 event_start_date: '20210713'
 event_end_date: '20210715'

--- a/docs/config.md
+++ b/docs/config.md
@@ -47,6 +47,7 @@ The configuration files are written in [yaml]() format and can/should include th
   default choice is kvf=3.
 - `timetracking`: true or false. Currently nothing is done with this setting
 - `distancetracking`: true or false. Currently nothing is done with this setting
+- `log_level`: "high" or "low". Setting it too high will print more info/warning messages.
 
 **Settings that control the period in which water is tracked**
 - `event_start_date`: formatted as 'YYYYMMDD', e.g. '20210713'


### PR DESCRIPTION
This PR adds a simple check to see whether any tagged moisture is lost during a timestep. For the example case (floodcase 2021), this gives me the following output:

```
2021-07-15 00:00:00
Lost moisture: -0.07%
2021-07-14 00:00:00
Lost moisture: -0.03%
2021-07-13 00:00:00
Lost moisture: -0.03%
2021-07-12 00:00:00
Lost moisture: 0.02%
2021-07-11 00:00:00
Lost moisture: 0.02%
2021-07-10 00:00:00
Lost moisture: 0.06%
2021-07-09 00:00:00
Lost moisture: 0.04%
2021-07-08 00:00:00
Lost moisture: 0.03%
2021-07-07 00:00:00
Lost moisture: -0.00%
2021-07-06 00:00:00
Lost moisture: 0.00%
2021-07-05 00:00:00
```

Which I would say is quite good.

I added an option to the config file called `log_level`. These checks will only be printed if `log_level` is set to `high`. This helps to keep the output clean, especially when we start adding more checks and warnings.

closes #127 