### PR TITLE
Refactor time loops

### DIFF
--- a/cases/era5_2013.yaml
+++ b/cases/era5_2013.yaml
@@ -15,7 +15,9 @@ track_start_date: '20130521'
 track_end_date: '20130604'
 
 # Settings needed for the tracking run
+input_frequency: '1h'
 target_frequency: '15min'
+output_frequency: '1d'
 periodic_boundary: false
 output_folder: ~/output_data
 restart: false

--- a/cases/era5_2021.yaml
+++ b/cases/era5_2021.yaml
@@ -15,7 +15,9 @@ track_start_date: '20210701'
 track_end_date: '20210716'
 
 # Settings needed for the tracking run
+input_frequency: '1h'
 target_frequency: '15min'
+output_frequency: '1d'
 periodic_boundary: false
 output_folder: ~/floodcase_202107/output_data
 restart: false

--- a/src/wam2layers/analysis/visualization.py
+++ b/src/wam2layers/analysis/visualization.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import click
 import matplotlib.pyplot as plt
 import xarray as xr
+import pandas as pd
 from cartopy import crs
 from cartopy import feature as cfeature
 from wam2layers.preprocessing.shared import get_grid_info
@@ -36,13 +37,19 @@ def visualize_output_data(config_file):
 def visualize_both(config_file):
     """Diagnostic figure with four subplots combining input and output data."""
     config = parse_config(config_file)
+    dates = pd.date_range(
+        start=config["track_start_date"],
+        end=config["track_end_date"],
+        freq=config["output_frequency"],
+        inclusive="left",
+    )
     region = load_region(config)
     a_gridcell, lx, ly = get_grid_info(region)
 
     out_dir = Path(config["output_folder"]) / "figures"
     out_dir.mkdir(exist_ok=True, parents=True)
 
-    for date in config["datelist"]:
+    for date in dates:
         print(date)
         ds_in = xr.open_dataset(input_path(date, config))
         ds_out = xr.open_dataset(output_path(date, config))

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -483,6 +483,24 @@ def load_variables(t, variables, config):
     }
 
 
+import time
+import psutil
+class Profiler:
+    def __init__(self):
+        self.t0 = time.time()
+        self.mem0 = self._current_memory()
+
+    def __call__(self):
+        """Report memory and time increments."""
+        dt = round((time.time() - self.t0), 2)
+        dmem = self._current_memory() - self.mem0
+        # self.t0 = time.time()
+        # self.mem0 = self._current_memory()
+        return dt, dmem
+
+    def _current_memory(self):
+        return psutil.Process().memory_info().rss / (1024 * 1024)
+
 
 def run_experiment(config_file):
     """Run a backtracking experiment from start to finish."""
@@ -491,13 +509,13 @@ def run_experiment(config_file):
     states = ["s_upper", "s_lower"]
     fluxes = ["fx_upper", "fx_lower", "fy_upper", "fy_lower", "evap", "precip"]
 
+    profile = Profiler()
     for time in reversed(config["datelist"]):
         t_next = time - pd.Timedelta(config["target_frequency"])
         input_current = load_variables(time, states+fluxes, config)
         states_next = load_variables(t_next, states, config)
 
-
-        print(time, input_current['precip'].mean())
+        print(time, input_current['precip'].mean(), profile())
         # Convert data to volumes
         # change_units(input_current, config["target_frequency"])
         # change_units(states_next, config["target_frequency"])

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -373,8 +373,8 @@ def backtrack(
     )[inner]
 
     # down and top: redistribute unaccounted water that is otherwise lost from the sytem
-    lower_to_upper = np.maximum(0, s_track_lower - states_next.s_lower)
-    upper_to_lower = np.maximum(0, s_track_upper - states_next.s_upper)
+    lower_to_upper = np.maximum(0, s_track_lower - states_next["s_lower"])
+    upper_to_lower = np.maximum(0, s_track_upper - states_next["s_upper"])
     s_track_lower[inner] = (s_track_lower - lower_to_upper + upper_to_lower)[inner]
     s_track_upper[inner] = (s_track_upper - upper_to_lower + lower_to_upper)[inner]
 

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -217,7 +217,7 @@ def calculate_fv(fluxes, states_prev, states_next):
     s_rel = s_mean / s_total
 
     tendency_upper = convergence(fluxes.fx_upper, fluxes.fy_upper) - fluxes.precip.values * s_rel.s_upper
-    tendency_lower = convergence(fluxes.fx_upper, fluxes.fy_upper) - fluxes.precip.values * s_rel.s_lower + fluxes.evap
+    tendency_lower = convergence(fluxes.fx_lower, fluxes.fy_lower) - fluxes.precip.values * s_rel.s_lower + fluxes.evap
 
     residual_upper = s_diff.s_upper - tendency_upper
     residual_lower = s_diff.s_lower - tendency_lower
@@ -434,19 +434,19 @@ def initialize(config_file):
 # With the correct import statements, the code in the function below could
 # alternatively be be used as a script in a separate python file or notebook.
 #############################################################################
-@lru_cache(maxsize=2)
+# @lru_cache(maxsize=2)
 def read_data_at_date(d):
     """Load input data for given date."""
     file = input_path(d, config)
     return xr.open_dataset(file, cache=False)
 
-@lru_cache(maxsize=2)
+# @lru_cache(maxsize=2)
 def read_data_at_time(t):
     """Get a single time slice from input data at time t."""
     ds = read_data_at_date(t)
     return ds.sel(time=t, drop=True)
 
-@lru_cache(maxsize=4)
+# @lru_cache(maxsize=4)
 def load_data(t, subset='fluxes'):
     """Load variable at t, interpolate if needed."""
     variables = {
@@ -466,6 +466,7 @@ def load_data(t, subset='fluxes'):
         return da0
 
     return da0 + (t - t0) / (t1 - t0) * (da1 - da0)
+
 
 def load_fluxes(t):
     t_current = t - pd.Timedelta(config['target_frequency']) / 2

--- a/src/wam2layers/utils/profiling.py
+++ b/src/wam2layers/utils/profiling.py
@@ -17,3 +17,45 @@ class Profiler:
 
     def _current_memory(self):
         return psutil.Process().memory_info().rss / (1024 * 1024)
+
+
+class ProgressTracker:
+    def __init__(self, output):
+        """Keep track of tagged and tracked moisture."""
+        self.total_tagged_moisture = 0
+        self.tracked = 0
+        self.boundary = 0
+        self.store_intermediate_states(output)
+        self.profile = Profiler()
+
+    def store_intermediate_states(self, output):
+        """Update moisture totals based on output since previous time step.
+
+        Intended for when the output fields are reset at write time, so we
+        don't lose accumulations from previous outputs.
+        """
+        totals = output.sum()
+        self.tracked += totals["e_track"]
+        self.total_tagged_moisture += totals["tagged_precip"]
+        self.boundary += (totals["north_loss"] + totals["south_loss"] + totals["east_loss"] + totals["west_loss"])
+
+    def print_progress(self, t, output):
+        """Print some useful runtime diagnostics."""
+        totals = output.sum()
+        tracked = self.tracked + totals["e_track"]
+        total_tagged_moisture = self.total_tagged_moisture + totals["tagged_precip"]
+        boundary = self.boundary + (totals["north_loss"] + totals["south_loss"] + totals["east_loss"] + totals["west_loss"])
+        still_in_atmosphere = (totals["s_track_upper_restart"] + totals["s_track_lower_restart"])
+
+        total_tracked_moisture = tracked + still_in_atmosphere + boundary
+        tracked_percentage = (tracked + boundary) / total_tagged_moisture * 100
+        lost_percentage = (1 - total_tracked_moisture / total_tagged_moisture) * 100
+
+        time, memory = self.profile()
+
+        print(
+            f"{t} - "
+            f"Tracked moisture: {tracked_percentage.item():.2f}%. "
+            f"Lost moisture: {lost_percentage.item():.2f}%. "
+            f"Time since start: {time}s, RAM: {memory:.2f} MB"
+        )

--- a/src/wam2layers/utils/profiling.py
+++ b/src/wam2layers/utils/profiling.py
@@ -1,0 +1,19 @@
+import time
+import psutil
+
+
+class Profiler:
+    def __init__(self):
+        self.t0 = time.time()
+        self.mem0 = self._current_memory()
+
+    def __call__(self):
+        """Report memory and time increments."""
+        dt = round((time.time() - self.t0), 2)
+        dmem = self._current_memory() - self.mem0
+        # self.t0 = time.time()
+        # self.mem0 = self._current_memory()
+        return dt, dmem
+
+    def _current_memory(self):
+        return psutil.Process().memory_info().rss / (1024 * 1024)


### PR DESCRIPTION
The original code used a nested loop like this (pseudo-code):

```py
for date in dates:
    data = load_data(date)  # hourly data, so 25 values since preproc files also included midnight of next day
    refined = interpolate('15min')  # so now 24*4+1 time steps in memory
    backtrack(refined)
    # The inner loop was hidden in the backtrack function:
    for time in refined:
        track_this_timestep()
```
As pointed out in the inline comments, this uses much more memory than is strictly needed. Moreover, the nested structure, with the inner loop hidden in a function, makes it difficult to see what's going on, and it makes it necessary to do bookkeeping in two places. Finally, the 25th hour in the input files is an ugly necessity that also complicates the preprocessing.

This PR changes the code such that it looks more like this  (pseudo-code):

```py
times = get_refined_timesteps()

for time in times:
    load_refined_data(time)  
    track_this_timestep()

def load_refined_data(time):
    upper, lower = find_bounds(time)
    load(upper)
    load(lower)
    return interp(upper, lower, t)
```

This considerably reduces memory consumption. Moreover, it removes a layer of complexity, making the code easier to understand and making it easier to e.g. write output at any desired frequency (this is now configurable).

Some side effects of this PR:
- Output writing frequency can be configured
- Nicer logging messages
- Removed output variables `s_track_upper` (and `lower`) because I felt they didn't really make sense
- Changed output to have "total" accumulations since start of tracking. This made the code much easier and it is still possible to get daily values by taking the output diff.
- I verified the output is still the same as before.
