### PR TITLE
Added periodic boundaries backtracking

### DIFF
--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 import yaml
+
 from wam2layers.preprocessing.shared import get_grid_info
 from wam2layers.utils.profiling import Profiler, ProgressTracker
 
@@ -316,10 +317,10 @@ def backtrack(
 
     # Determine horizontal fluxes over the grid-cell boundaries
     f_e_lower_we, f_e_lower_ew, f_w_lower_we, f_w_lower_ew = to_edges_zonal(
-        fx_lower
+        fx_lower, config["periodic_boundary"]
     )
     f_e_upper_we, f_e_upper_ew, f_w_upper_we, f_w_upper_ew = to_edges_zonal(
-        fx_upper
+        fx_upper, config["periodic_boundary"]
     )
 
     (
@@ -338,7 +339,10 @@ def backtrack(
     # Short name for often used expressions
     s_track_relative_lower = s_track_lower / s_lower
     s_track_relative_upper = s_track_upper / s_upper
-    inner = np.s_[1:-1, 1:-1]
+    if config["periodic_boundary"]:
+        inner = np.s_[1:-1, :]
+    else:
+        inner = np.s_[1:-1, 1:-1]
 
     # Actual tracking (note: backtracking, all terms have been negated)
     s_track_lower[inner] += (
@@ -386,14 +390,16 @@ def backtrack(
         fy_s_upper_sn * s_track_relative_upper
         + fy_s_lower_sn * s_track_relative_lower
     )[-2, :]
-    output["east_loss"] += (
-        f_e_upper_ew * s_track_relative_upper
-        + f_e_lower_ew * s_track_relative_lower
-    )[:, -2]
-    output["west_loss"] += (
-        f_w_upper_we * s_track_relative_upper
-        + f_w_lower_we * s_track_relative_lower
-    )[:, 1]
+
+    if config["periodic_boundary"] == False:
+        output["east_loss"] += (
+            f_e_upper_ew * s_track_relative_upper
+            + f_e_lower_ew * s_track_relative_lower
+        )[:, -2]
+        output["west_loss"] += (
+            f_w_upper_we * s_track_relative_upper
+            + f_w_lower_we * s_track_relative_lower
+        )[:, 1]
 
     output["s_track_lower_restart"].values = s_track_lower
     output["s_track_upper_restart"].values = s_track_upper


### PR DESCRIPTION
Check in backtrack.py whether periodic boundaries are set in configuration. If so, set east/west loss to 0 in output, and make sure data is continuous over the east/west edges of the grid.

closes #136