### PR TITLE
fix for reading single date and set prefix

### DIFF
--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -20,11 +20,13 @@ def load_data(variable, date, config):
             prefix = '_ml'
         elif config["level_type"] == "pressure_levels":
             prefix = '_pl'
+    else:
+        prefix = ''
 
     template = config["filename_template"]
     filepath = template.format(year=date.year, month=date.month, day= date.day, levtype=prefix, variable = variable)
 
-    da = xr.open_dataset(filepath)[variable]
+    da = xr.open_dataset(filepath)[variable].sel(time=date.strftime('%Y%m%d'))
 
     if "lev" in da.coords:
         da = da.rename(lev="level")


### PR DESCRIPTION
This PR solves the issue where preprocessing failed due to prefix accessed before assignment.

Also it adds back the date selection in loading data for backward compatibility with previous data filenaming convention.