### PR TITLE
Single precision of output data

### DIFF
--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -273,7 +273,7 @@ def prep_experiment(config_file):
         # Save preprocessed data
         filename = f"{date.strftime('%Y-%m-%d')}_fluxes_storages.nc"
         output_path = config["output_dir"] / filename
-        ds.to_netcdf(output_path)
+        ds.to_netcdf(output_path) #.astype("float32")
 
 ################################################################################
 # To run this script interactively in e.g. Spyder, uncomment the following line:

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -273,7 +273,7 @@ def prep_experiment(config_file):
         # Save preprocessed data
         filename = f"{date.strftime('%Y-%m-%d')}_fluxes_storages.nc"
         output_path = config["output_dir"] / filename
-        ds.to_netcdf(output_path) #.astype("float32")
+        ds.astype("float32").to_netcdf(output_path)
 
 ################################################################################
 # To run this script interactively in e.g. Spyder, uncomment the following line:

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -451,7 +451,7 @@ def write_output(output, t):
     # TODO: add back (and cleanup) coordinates and units
     path = output_path(t, config)
     print(f"{t} - Writing output to file {path}")
-    output.to_netcdf(path)
+    output.to_netcdf(path) #.astype("float32")
 
     # Flush previous outputs
     output[["e_track", "tagged_precip", "north_loss", "south_loss", "east_loss", "west_loss"]] *= 0

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -451,7 +451,7 @@ def write_output(output, t):
     # TODO: add back (and cleanup) coordinates and units
     path = output_path(t, config)
     print(f"{t} - Writing output to file {path}")
-    output.to_netcdf(path) #.astype("float32")
+    output.astype("float32").to_netcdf(path)
 
     # Flush previous outputs
     output[["e_track", "tagged_precip", "north_loss", "south_loss", "east_loss", "west_loss"]] *= 0


### PR DESCRIPTION
As discussed, the changes in the results using single precision output are very small (on the order of 10^-4 %). Moreover the input data (at least era5) is often in the short data format, which is less precise than single precision. 