### PR TITLE
Conditionally import cartopy and give a better error message if it fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
     "netcdf4",
     "scipy",
     "click",
-    ## Cartopy requires GEOS and PROJ
-    ## recommend installing with conda instead
-    # cartopy
+    "psutil",
+    "matplotlib",
+    "cmocean",
 ]
 
 [project.optional-dependencies]

--- a/src/wam2layers/analysis/visualization.py
+++ b/src/wam2layers/analysis/visualization.py
@@ -4,12 +4,25 @@ import click
 import matplotlib.pyplot as plt
 import xarray as xr
 import pandas as pd
-from cartopy import crs
-from cartopy import feature as cfeature
 from cmocean import cm
 from wam2layers.preprocessing.shared import get_grid_info
 from wam2layers.tracking.backtrack import (input_path, load_region,
                                            output_path, parse_config)
+
+
+def try_import_cartopy():
+    """Import cartopy if it is available; else raise."""
+    from importlib import import_module
+
+    global crs
+    global cfeature
+
+    try:
+        crs = import_module('cartopy.crs')
+        cfeature = import_module('cartopy.feature')
+    except ImportError as exec:
+        message = "This function requires cartopy. Cartopy is most easily installed with conda. Please refer to the documentation."
+        raise ImportError(message) from exec
 
 
 def polish(ax, region):
@@ -183,6 +196,7 @@ def cli():
 @click.argument('config_file', type=click.Path(exists=True))
 def input(config_file):
     """Visualize input data for experiment."""
+    try_import_cartopy()
     visualize_input_data(config_file)
 
 
@@ -190,6 +204,7 @@ def input(config_file):
 @click.argument('config_file', type=click.Path(exists=True))
 def output(config_file):
     """Visualize output data for experiment."""
+    try_import_cartopy()
     visualize_output_data(config_file)
 
 
@@ -197,6 +212,7 @@ def output(config_file):
 @click.argument('config_file', type=click.Path(exists=True))
 def both(config_file):
     """Visualize both input and output data for experiment."""
+    try_import_cartopy()
     visualize_both(config_file)
 
 
@@ -204,6 +220,7 @@ def both(config_file):
 @click.argument('config_file', type=click.Path(exists=True))
 def snapshots(config_file):
     """Visualize input and output snapshots for experiment."""
+    try_import_cartopy()
     visualize_snapshots(config_file)
 
 

--- a/src/wam2layers/cli.py
+++ b/src/wam2layers/cli.py
@@ -2,16 +2,7 @@
 import click
 from wam2layers.tracking.backtrack import cli as backtrack_cli
 from wam2layers.preprocessing.cli import cli as preproc_cli
-
-# Visualization requires optional dependencies that may not be installed.
-try:
-    from wam2layers.analysis.visualization import cli as visualize_cli
-    include_visualize = True
-except ImportError:
-    include_visualize = False
-    click.echo(
-        "To enable visualization options, install matplotlib and cartopy. "
-    )
+from wam2layers.analysis.visualization import cli as visualize_cli
 
 
 @click.group()
@@ -22,7 +13,4 @@ def cli():
 
 cli.add_command(preproc_cli, name="preprocess")
 cli.add_command(backtrack_cli, name="backtrack")
-
-# Visualization requires optional dependencies that may not be installed.
-if include_visualize:
-    cli.add_command(visualize_cli, name="visualize")
+cli.add_command(visualize_cli, name="visualize")


### PR DESCRIPTION
This fixes #149 .

- Cartopy is no longer imported by default in `visualization.py`. So we can import `wam2layers.analysis.visualization`  without getting import errors.
- When any of the visualization functions is called (i.e. the users tries to make a plot), `try_import_cartopy` is called. 
  - If this works, nothing unexpected happens
  - If this fails, we get a clear error message instructing the user to install cartopy with conda.
- matplotlib and cmocean are added as standard dependencies