### PR TITLE
Fix output filenames to include hours and minutes

### DIFF
--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -37,8 +37,7 @@ def input_path(date, config):
 
 def output_path(date, config):
     output_dir = config.output_folder
-    return f"{output_dir}/{date.strftime('%Y-%m-%d')}_s_track.nc"
-
+    return f"{output_dir}/backtrack_{date.strftime('%Y-%m-%dT%H:%M')}.nc"
 
 # LRU Cache keeps the file open so we save a bit on I/O
 @lru_cache(maxsize=2)


### PR DESCRIPTION
This PR solves a bug where the output filenames only include dates and no time. When the output frequency is set to more than one output file per day, the previous file is overridden. This PR adds hours and minutes to the output files.

Closes #229 
Refs #218 