### PR TITLE
Adjusted line 178 for equal pressure levels to >=

### DIFF
--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -171,8 +171,6 @@ def get_dp_pressurelevels(q, u, v, ps, qs, us, vs):
     q = q.assign_coords(level=np.arange(nlev))
     p = p.assign_coords(level=np.arange(nlev))
 
-    # import IPython; IPython.embed(); quit()
-
     # Calculate pressure jump
     dp = p.diff("level")
     assert np.all(dp >= 0), "Pressure levels should increase monotonically"

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -171,9 +171,11 @@ def get_dp_pressurelevels(q, u, v, ps, qs, us, vs):
     q = q.assign_coords(level=np.arange(nlev))
     p = p.assign_coords(level=np.arange(nlev))
 
+    # import IPython; IPython.embed(); quit()
+
     # Calculate pressure jump
     dp = p.diff("level")
-    assert np.all(dp > 0), "Pressure levels should increase monotonically"
+    assert np.all(dp >= 0), "Pressure levels should increase monotonically"
 
     # Interpolate to midpoints
     midpoints = 0.5 * (u.level.values[1:] + u.level.values[:-1])


### PR DESCRIPTION
I adjusted the line 178 in era5 pre-processing. I ran into the problem of having dp = 0 due to pressure level and surface pressure being exactly equal. By changing > to >=, this problem seems to be resolved. By comparing pressure and model levels, we can see whether this results in any issues. 