### PR TITLE
modified lower and upper tracking to ensure that the maximum fraction tracked never exceeds 100%

### DIFF
--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -323,8 +323,9 @@ def backtrack(
     ) = to_edges_meridional(fy_upper)
 
     # Short name for often used expressions
-    s_track_relative_lower = s_track_lower / s_lower
-    s_track_relative_upper = s_track_upper / s_upper
+    s_track_relative_lower = np.minimum(s_track_lower / s_lower, 1.0)
+    s_track_relative_upper = np.minimum(s_track_upper / s_upper, 1.0)
+
     if config.periodic_boundary:
         inner = np.s_[1:-1, :]
     else:
@@ -367,7 +368,7 @@ def backtrack(
     s_track_upper[inner] = (s_track_upper - upper_to_lower + lower_to_upper)[inner]
 
     # Update output fields
-    output["e_track"] += evap * (s_track_lower / s_lower)
+    output["e_track"] += evap * np.minimum(s_track_lower / s_lower, 1.0)
     output["north_loss"] += (
         fy_n_upper_ns * s_track_relative_upper + fy_n_lower_ns * s_track_relative_lower
     )[1, :]


### PR DESCRIPTION
This 3-line edit in the backtrack.py fixes a bug where the amount tracked could exceed 100%. While in many cases this was not a proble, there were certain locations and timestamps where this caused the backtracking to explode (i.e. percent tracked exceeding 1000000%, etc). The fix is to cap the fraction tracked to 1.0.