### PR TITLE
Preprocess one time step at a time

### DIFF
--- a/src/wam2layers/config.py
+++ b/src/wam2layers/config.py
@@ -271,31 +271,6 @@ class Config(BaseModel):
 
     """
 
-    chunks: Optional[Dict[str, int]]
-    """Whether to use dask.
-
-    Using dask can help process large datasets without memory issues, but its
-    performance is quite sensitive to the chunk configuration.
-
-    Some examples:
-
-    .. code-block:: yaml
-
-        # don't use dask:
-        chunks: null
-
-        # process one time step at a time
-        chunks: {time: 1}
-
-        # set chunking for all individual dims
-        chunks:
-            level: -1
-            time: 1  # don't set time to auto, as it will be different for surface and 3d vars
-            latitude: auto
-            longitude: auto
-
-    """
-
     @classmethod
     def from_yaml(cls, config_file):
         """Read settings from a configuration.yaml file.

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -6,7 +6,6 @@ import click
 import numpy as np
 import pandas as pd
 import xarray as xr
-from IPython import embed
 
 from wam2layers.config import Config
 from wam2layers.preprocessing.shared import (

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -40,8 +40,8 @@ def load_data(variable, date, config):
         levtype=prefix,
         variable=variable,
     )
-    da = xr.open_dataset(filepath, chunks=config.chunks).sel(
-        time=date.strftime("%Y%m%d")
+    da = xr.open_dataset(filepath).sel(
+        time=datetime.strftime("%Y%m%d")
     )[variable]
 
     if "lev" in da.coords:
@@ -226,13 +226,6 @@ def prep_experiment(config_file):
     """
     config = Config.from_yaml(config_file)
 
-    if config.chunks is not None:
-        logger.info("Starting dask cluster")
-        from dask.distributed import Client
-
-        client = Client()
-        logger.info(f"To see the dask dashboard, go to {client.dashboard_link}")
-
     for date in get_input_dates(config):
         logger.info(date)
 
@@ -318,10 +311,6 @@ def prep_experiment(config_file):
         filename = f"{date.strftime('%Y-%m-%d')}_fluxes_storages.nc"
         output_path = config.preprocessed_data_folder / filename
         ds.astype("float32").to_netcdf(output_path)
-
-    # Close the dask cluster when done
-    if config.chunks is not None:
-        client.shutdown()
 
 
 ################################################################################

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -336,7 +336,7 @@ def prep_experiment(config_file):
         if is_new_day:
             ds.to_netcdf(output_path, unlimited_dims=["time"], mode="w")
         else:
-            append_to_netcdf(output_path, ds, unlimited_dims="time")
+            append_to_netcdf(output_path, ds, expanding_dim="time")
 
 
 ################################################################################

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -333,11 +333,9 @@ def prep_experiment(config_file):
         # Save preprocessed data
         filename = f"{datetime.strftime('%Y-%m-%d')}_fluxes_storages.nc"
         output_path = config.preprocessed_data_folder / filename
-        # TODO append is tricky; clear folder before starting?
-        if not output_path.exists():
-            ds.to_netcdf(output_path, unlimited_dims=["time"], mode="a")
+        if is_new_day:
+            ds.to_netcdf(output_path, unlimited_dims=["time"], mode="w")
         else:
-            # TODO: append doesn't overwrite existing but rather adds a duplicate time.
             append_to_netcdf(output_path, ds, unlimited_dims="time")
 
 

--- a/src/wam2layers/preprocessing/era5.py
+++ b/src/wam2layers/preprocessing/era5.py
@@ -274,7 +274,7 @@ def prep_experiment(config_file):
             cw = cwv
             log_once(
                 logger, f"Total column water not available; using water vapour only"
-            )  # CONTINUE HERE
+            )  
 
         # Determine the fluxes
         fx = u * cw  # eastward atmospheric moisture flux (kg m-1 s-1)

--- a/src/wam2layers/preprocessing/shared.py
+++ b/src/wam2layers/preprocessing/shared.py
@@ -260,7 +260,7 @@ def calculate_humidity(dewpoint, pressure):
     return spec_hum
 
 
-def accumulation_to_flux(data):
+def accumulation_to_flux(data, input_frequency):
     """Convert precip and evap from accumulations to fluxes.
 
     Incoming data should have units of "m"
@@ -269,7 +269,7 @@ def accumulation_to_flux(data):
     that the times should be shifted. A good fix for this is welcome.
     """
     density = 1000  # [kg/m3]
-    timestep = pd.Timedelta(data.time.diff("time")[0].values)
+    timestep = pd.Timedelta(input_frequency)
     nseconds = timestep.total_seconds()
 
     fluxdata = (density * data / nseconds).assign_attrs(units="kg m-2 s-1")

--- a/src/wam2layers/preprocessing/xarray_append.py
+++ b/src/wam2layers/preprocessing/xarray_append.py
@@ -1,0 +1,67 @@
+"""
+Utility for appending to netcdf file along unlimited dimension.
+Taken from https://github.com/pydata/xarray/issues/1672#issuecomment-685222909
+"""
+
+import netCDF4
+import xarray as xr
+
+
+def _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size):
+    # For time deltas, we must ensure that we use the same encoding as
+    # what was previously stored.
+    # We likely need to do this as well for variables that had custom
+    # econdings too
+    if hasattr(nc_variable, 'calendar'):
+
+        data.encoding = {
+            'units': nc_variable.units,
+            'calendar': nc_variable.calendar,
+        }
+    data_encoded = xr.conventions.encode_cf_variable(data) # , name=name)
+    left_slices = data.dims.index(expanding_dim)
+    right_slices = data.ndim - left_slices - 1
+    nc_slice   = (slice(None),) * left_slices + (slice(nc_shape, nc_shape + added_size),) + (slice(None),) * (right_slices)
+    nc_variable[nc_slice] = data_encoded.data
+
+def append_to_netcdf(filename, ds_to_append, unlimited_dims):
+    if isinstance(unlimited_dims, str):
+        unlimited_dims = [unlimited_dims]
+
+    if len(unlimited_dims) != 1:
+        # TODO: change this so it can support multiple expanding dims
+        raise ValueError(
+            "We only support one unlimited dim for now, "
+            f"got {len(unlimited_dims)}.")
+
+    unlimited_dims = list(set(unlimited_dims))
+    expanding_dim = unlimited_dims[0]
+
+    with netCDF4.Dataset(filename, mode='a') as nc:
+        nc_dims = set(nc.dimensions.keys())
+
+        nc_coord = nc[expanding_dim]
+        nc_shape = len(nc_coord)
+        added_size = len(ds_to_append[expanding_dim])
+        variables, attrs = xr.conventions.encode_dataset_coordinates(ds_to_append)
+
+        for name, data in variables.items():
+            if expanding_dim not in data.dims:
+                # Nothing to do, data assumed to the identical
+                continue
+
+            nc_variable = nc[name]
+            _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size)
+
+
+if __name__=="__main__":
+    from xarray.tests.test_dataset import create_append_test_data
+    from xarray.testing import assert_equal
+    ds, ds_to_append, ds_with_new_var = create_append_test_data()
+
+    filename = 'test_dataset.nc'
+    ds.to_netcdf(filename, mode='w', unlimited_dims=['time'])
+    append_to_netcdf('test_dataset.nc', ds_to_append, unlimited_dims='time')
+
+    loaded = xr.load_dataset('test_dataset.nc')
+    assert_equal(xr.concat([ds, ds_to_append], dim="time"), loaded)

--- a/src/wam2layers/preprocessing/xarray_append.py
+++ b/src/wam2layers/preprocessing/xarray_append.py
@@ -1,6 +1,6 @@
 """
 Utility for appending to netcdf file along unlimited dimension.
-Taken from https://github.com/pydata/xarray/issues/1672#issuecomment-685222909
+Adapted from https://github.com/pydata/xarray/issues/1672#issuecomment-685222909
 """
 
 import netCDF4
@@ -17,7 +17,7 @@ def _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size):
             "units": nc_variable.units,
             "calendar": nc_variable.calendar,
         }
-    data_encoded = xr.conventions.encode_cf_variable(data)  # , name=name)
+    data_encoded = xr.conventions.encode_cf_variable(data)
     left_slices = data.dims.index(expanding_dim)
     right_slices = data.ndim - left_slices - 1
     nc_slice = (
@@ -28,22 +28,8 @@ def _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size):
     nc_variable[nc_slice] = data_encoded.data
 
 
-def append_to_netcdf(filename, ds_to_append, unlimited_dims):
-    if isinstance(unlimited_dims, str):
-        unlimited_dims = [unlimited_dims]
-
-    if len(unlimited_dims) != 1:
-        # TODO: change this so it can support multiple expanding dims
-        raise ValueError(
-            "We only support one unlimited dim for now, " f"got {len(unlimited_dims)}."
-        )
-
-    unlimited_dims = list(set(unlimited_dims))
-    expanding_dim = unlimited_dims[0]
-
+def append_to_netcdf(filename, ds_to_append, expanding_dim="time"):
     with netCDF4.Dataset(filename, mode="a") as nc:
-        nc_dims = set(nc.dimensions.keys())
-
         nc_coord = nc[expanding_dim]
         nc_shape = len(nc_coord)
         added_size = len(ds_to_append[expanding_dim])
@@ -56,17 +42,3 @@ def append_to_netcdf(filename, ds_to_append, unlimited_dims):
 
             nc_variable = nc[name]
             _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size)
-
-
-if __name__ == "__main__":
-    from xarray.testing import assert_equal
-    from xarray.tests.test_dataset import create_append_test_data
-
-    ds, ds_to_append, ds_with_new_var = create_append_test_data()
-
-    filename = "test_dataset.nc"
-    ds.to_netcdf(filename, mode="w", unlimited_dims=["time"])
-    append_to_netcdf("test_dataset.nc", ds_to_append, unlimited_dims="time")
-
-    loaded = xr.load_dataset("test_dataset.nc")
-    assert_equal(xr.concat([ds, ds_to_append], dim="time"), loaded)

--- a/src/wam2layers/preprocessing/xarray_append.py
+++ b/src/wam2layers/preprocessing/xarray_append.py
@@ -12,17 +12,21 @@ def _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size):
     # what was previously stored.
     # We likely need to do this as well for variables that had custom
     # econdings too
-    if hasattr(nc_variable, 'calendar'):
-
+    if hasattr(nc_variable, "calendar"):
         data.encoding = {
-            'units': nc_variable.units,
-            'calendar': nc_variable.calendar,
+            "units": nc_variable.units,
+            "calendar": nc_variable.calendar,
         }
-    data_encoded = xr.conventions.encode_cf_variable(data) # , name=name)
+    data_encoded = xr.conventions.encode_cf_variable(data)  # , name=name)
     left_slices = data.dims.index(expanding_dim)
     right_slices = data.ndim - left_slices - 1
-    nc_slice   = (slice(None),) * left_slices + (slice(nc_shape, nc_shape + added_size),) + (slice(None),) * (right_slices)
+    nc_slice = (
+        (slice(None),) * left_slices
+        + (slice(nc_shape, nc_shape + added_size),)
+        + (slice(None),) * (right_slices)
+    )
     nc_variable[nc_slice] = data_encoded.data
+
 
 def append_to_netcdf(filename, ds_to_append, unlimited_dims):
     if isinstance(unlimited_dims, str):
@@ -31,13 +35,13 @@ def append_to_netcdf(filename, ds_to_append, unlimited_dims):
     if len(unlimited_dims) != 1:
         # TODO: change this so it can support multiple expanding dims
         raise ValueError(
-            "We only support one unlimited dim for now, "
-            f"got {len(unlimited_dims)}.")
+            "We only support one unlimited dim for now, " f"got {len(unlimited_dims)}."
+        )
 
     unlimited_dims = list(set(unlimited_dims))
     expanding_dim = unlimited_dims[0]
 
-    with netCDF4.Dataset(filename, mode='a') as nc:
+    with netCDF4.Dataset(filename, mode="a") as nc:
         nc_dims = set(nc.dimensions.keys())
 
         nc_coord = nc[expanding_dim]
@@ -54,14 +58,15 @@ def append_to_netcdf(filename, ds_to_append, unlimited_dims):
             _expand_variable(nc_variable, data, expanding_dim, nc_shape, added_size)
 
 
-if __name__=="__main__":
-    from xarray.tests.test_dataset import create_append_test_data
+if __name__ == "__main__":
     from xarray.testing import assert_equal
+    from xarray.tests.test_dataset import create_append_test_data
+
     ds, ds_to_append, ds_with_new_var = create_append_test_data()
 
-    filename = 'test_dataset.nc'
-    ds.to_netcdf(filename, mode='w', unlimited_dims=['time'])
-    append_to_netcdf('test_dataset.nc', ds_to_append, unlimited_dims='time')
+    filename = "test_dataset.nc"
+    ds.to_netcdf(filename, mode="w", unlimited_dims=["time"])
+    append_to_netcdf("test_dataset.nc", ds_to_append, unlimited_dims="time")
 
-    loaded = xr.load_dataset('test_dataset.nc')
+    loaded = xr.load_dataset("test_dataset.nc")
     assert_equal(xr.concat([ds, ds_to_append], dim="time"), loaded)


### PR DESCRIPTION
By manually stepping over each time step in the output data, we can preprocess everything without using dask. This makes it easier to do logging et cetera, and we don't have the overhead of dask.

A potential downside of it is that with dask, you could have pre-processed, let's say, 7 timesteps at once if the memory permitted it. And it could have done it in parallel. Now, we're bound to the limit of 1 timestep at a time, one after the other.

Since xarray can't append along a dimension, I have used a snippet from one of their github issues: https://github.com/pydata/xarray/issues/1672#issuecomment-685222909

TODO: 

- [x] Now I'm appending time steps to an existing file, instead of (over)writing an entire file at once. Due to this, if the file already exists, things get messy. It would be good to have a better handling of "overwriting" behaviour.
- [x] Simplify the code snippet a bit that I copied from the xarray gh thread (only needs to deal with time, always one step at a time)