### PR TITLE
Add plots of the difference in the regression tests

### DIFF
--- a/src/wam2layers/analysis/checks.py
+++ b/src/wam2layers/analysis/checks.py
@@ -5,7 +5,7 @@ import numpy as np
 import yaml
 
 
-def _warning_on_one_line(message, category, filename, lineno, file=None, line=None):
+def _warning_on_one_line(message, category, filename, lineno, line=None):
     """A more compact warning format.
 
     https://stackoverflow.com/a/26433913

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,12 +1,51 @@
 """Tests for entire workflows."""
 from pathlib import Path
 
+import matplotlib.colors
 import matplotlib.testing.compare
 import numpy
 import xarray as xr
 from click.testing import CliRunner
+from matplotlib import pyplot as plt
 
 from wam2layers.cli import cli
+
+try:  # Use cartopy if it's available
+    import cartopy.feature as cfeature
+    from cartopy import crs
+except ImportError:
+    crs = None
+    cfeature = None
+
+
+def plot_difference(
+    expected_output: xr.DataArray, output: xr.DataArray, fpath: Path
+) -> None:
+    """Plot the difference between the expected output and actual output."""
+    if not fpath.parent.exists():
+        fpath.parent.mkdir()  # Make figures directory if it does not exist yet
+
+    if crs is not None:
+        subplot_kw = dict(projection=crs.PlateCarree())
+    else:
+        subplot_kw = None
+
+    fig, ax = plt.subplots(
+        figsize=(16, 10),
+        subplot_kw=subplot_kw,
+    )
+    (expected_output - output).plot.pcolormesh(
+        ax=ax,
+        x="longitude",
+        cmap="RdBu",
+        norm=matplotlib.colors.TwoSlopeNorm(vcenter=0),
+    )
+    if cfeature is not None:
+        ax.add_feature(cfeature.COASTLINE, linewidth=0.8)
+        ax.add_feature(cfeature.BORDERS, linestyle="-", linewidth=0.2)
+
+    ax.set_title(f"Difference between expected and actual '{output.name}' values.")
+    fig.savefig(fpath, dpi=200)
 
 
 def test_preprocess():
@@ -22,11 +61,20 @@ def test_preprocess():
         "tests/test_data/verify_output/2022-08-31_fluxes_storages.nc"
     )
     output = xr.open_dataset(output_path)
+
+    diff_figure_path = Path("tests/tmp/output_data/figures/preprocess_precip_diff.png")
+    plot_difference(
+        expected_output["precip"].sum("time"),
+        output["precip"].sum("time"),
+        diff_figure_path,
+    )
+
     numpy.testing.assert_allclose(
         expected_output["precip"].values,
         output["precip"].values,
         err_msg=(
             "Output results are different! Please verify your results. \n"
+            f"A difference plot is available under {diff_figure_path}. \n"
             "If you want to keep the new results and include it in your commit, \n"
             "you can update the reference data with the following command: \n"
             "`cp tests/tmp/preprocessed_data/2022-08-31_fluxes_storages.nc tests/test_data/verify_output/2022-08-31_fluxes_storages.nc`"
@@ -55,11 +103,16 @@ def test_backtrack():
         "tests/test_data/verify_output/backtrack_2022-08-31T18-00.nc"
     )
     output = xr.open_dataset(output_path)
+
+    diff_figure_path = Path("tests/tmp/output_data/figures/backtrack_diff.png")
+    plot_difference(expected_output["e_track"], output["e_track"], diff_figure_path)
+
     numpy.testing.assert_allclose(
         expected_output["e_track"].values,
         output["e_track"].values,
         err_msg=(
             "Output results are different! Please verify your results. \n"
+            f"A difference plot is available under {diff_figure_path}. \n"
             "If you want to keep the new results and include it in your commit, \n"
             "you can update the reference data with the following command: \n"
             "`cp tests/tmp/output_data/backtrack_2022-08-31T18-00.nc tests/test_data/verify_output/backtrack_2022-08-31T18-00.nc`"


### PR DESCRIPTION
To make it easier to quickly see what went wrong, I expanded the workflow tests with a plotting function.
Plots of the difference between the expected and actual outputs are generated for the preprocessing and backward tracking tests.

I also fixed a small mistake in analysis/checks.py: The stackoverflow answer was (slightly) incorrect, which was detected by [mypy](https://mypy-lang.org/).