### PR TITLE
Modify stability correction warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - The workflow tests use a temporary directory managed by pytest and the user's operating system, to avoid the `/tmp` folder polluting the workspace ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - The workflow tests now make extensive use of pytest's [fixtures](https://docs.pytest.org/en/8.0.x/explanation/fixtures.html), which will make future test writing easier ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - The `kvf` parameter can now be a floating point number instead of an integer ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
+- The stability correction warning will now occur only when 10% more of the grid is corrected compared to last warning, or the correction factor is 10% stronger.
 
 ## Release v3.0.0-beta.6 (2023-12-22)
 

--- a/src/wam2layers/preprocessing/shared.py
+++ b/src/wam2layers/preprocessing/shared.py
@@ -5,6 +5,9 @@ import pandas as pd
 import xarray as xr
 from scipy.interpolate import interp1d
 
+from wam2layers.config import Config
+from wam2layers.utils.profiling import ProgressTracker
+
 
 # old, keep only for reference and ecearth starting case
 def resample(variable, divt, count_time, method="interp"):
@@ -337,7 +340,7 @@ def change_units(data, target_freq):
         data[variable] = data[variable].assign_attrs(units="m**3")
 
 
-def stabilize_fluxes(F, S, progress_tracker, config, t):
+def stabilize_fluxes(F, S, progress_tracker: ProgressTracker, config: Config, t):
     """Stabilize the outfluxes / influxes.
 
     CFL: Water cannot move further than one grid cell per timestep.
@@ -358,7 +361,7 @@ def stabilize_fluxes(F, S, progress_tracker, config, t):
         fy_limit = 1 / 2 * fy_abs / ft_abs * s.values
         fy_stable = np.minimum(fy_abs, fy_limit)
 
-        progress_tracker.track_stability_correction(fy_limit, fy_abs, config, t)
+        progress_tracker.track_stability_correction(fy_stable, fy_abs, config, t)
 
         # Get rid of any nan values
         fx_stable.fillna(0)


### PR DESCRIPTION
When working together with Ruud, we noticed some issues with the stability correction warning.

The checks have been modified slightly, and will now alert the user when:

1. At least 5% of the grid was corrected (first time), or the area corrected has increased by 10% (afterwards).
2. The correction factor (its value is 0 - 1, lower numbers is stronger correction) is 10% lower (i.e. stronger).

