### PR TITLE
Deprecate Python 3.8. Add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     env:
       MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,26 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- made some updates to the visualization: more generic for forward and backward tracking
+- Updated the visualization: more generic for forward and backward tracking ([#318](https://github.com/WAM2layers/WAM2layers/pull/318)).
 - Add difference plots to the regression tests (`test_workflow.py`). The plots are uploaded as "artifacts" on Github Actions for easy inspection ([#319](https://github.com/WAM2layers/WAM2layers/pull/319)).
 - Added an export to file method for the configuration object (`wam2layers.config.Config`) to allow for easier testing of the command line interface ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - Added a regression test for the forward tracking workflow ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
+- Added support for Python 3.12 ([#333](https://github.com/WAM2layers/WAM2layers/pull/333)).
+- Adopted [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) as version support policy ([#333](https://github.com/WAM2layers/WAM2layers/pull/333)).
 
 ### Removed
 
+- Support for Python 3.8 has been removed. This is in line with the new policy ([following NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html)) ([#333](https://github.com/WAM2layers/WAM2layers/pull/333)).
+
 ### Fixed
 
-- Fixed a bug in the profiler's `track_stability_correction` method ([#325](https://github.com/WAM2layers/WAM2layers/pull/320)).
+- Fixed a bug in the profiler's `track_stability_correction` method ([#325](https://github.com/WAM2layers/WAM2layers/pull/325)).
 
 ### Changed
 - The workflow tests use a temporary directory managed by pytest and the user's operating system, to avoid the `/tmp` folder polluting the workspace ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - The workflow tests now make extensive use of pytest's [fixtures](https://docs.pytest.org/en/8.0.x/explanation/fixtures.html), which will make future test writing easier ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - The `kvf` parameter can now be a floating point number instead of an integer ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
-- The stability correction warning will now occur only when 10% more of the grid is corrected compared to last warning, or the correction factor is 10% stronger.
+- The stability correction warning will now occur only when 10% more of the grid is corrected compared to last warning, or the correction factor is 10% stronger  ([#332](https://github.com/WAM2layers/WAM2layers/pull/332)).
 
 ## Release v3.0.0-beta.6 (2023-12-22)
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -451,6 +451,11 @@ unrelated) changes. They can be set up to be run automatically when you make a p
 pytest tests/
 ```
 
+It is possible to run a single test (for example, when debugging). For example:
+```
+pytest tests/test_workflow.py::TestBacktrack::test_backtrack
+```
+
 For more information, please have a look at the documentation of pytest.
 
 ### Typing

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -453,7 +453,7 @@ pytest tests/
 
 For more information, please have a look at the documentation of pytest.
 
-## Typing
+### Typing
 
 Since Python 3.5 type hints can be added to Python code.
 These denote what the types of objects and function arguments should be.
@@ -482,3 +482,9 @@ mypy src/ --install-types --ignore-missing-imports
 `install-types` only needs to be run the first time, afterwards this is not needed.
 
 If you are unsure about adding types, it is not required so you can leave them out.
+
+### Python version support
+
+In WAM2layers we follow Numpy's version support policy ([NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html)).
+
+This means that new releases will only support minor Python versions (e.g. 3.9, 3.10) which have been released within the last 42 months.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
   "moisture recycling",
   "moisture tracking",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9, <3.13"
 dependencies = [
     "numpy",
     "pyyaml",


### PR DESCRIPTION
I removed Python 3.8. I expected 3.12 to work now, and it does (see passing test)