### PR TITLE
Add publishing action, update dev docs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,49 @@
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/wam2layers
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Added support for Python 3.12 ([#333](https://github.com/WAM2layers/WAM2layers/pull/333)).
 - Adopted [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) as version support policy ([#333](https://github.com/WAM2layers/WAM2layers/pull/333)).
 - The output files now contain many attributes for easier interpretation ([#334](https://github.com/WAM2layers/WAM2layers/pull/334)).
+- Publishing of the package to the Python Package Index ([PyPI](https://pypi.org/)) is now automated with a Github Actions workflow ([#342](https://github.com/WAM2layers/WAM2layers/pull/342)).
 
 ### Removed
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -243,9 +243,6 @@ publications.
 
 These instructions are intended for core developers.
 
-You need an [account on PyPI](https://pypi.org/account/register/) with owner
-rights on WAM2layers.
-
 - Create a new branch, e.g. `prep_release_vXXX`
 - Update "version" in `src/wam2layers/__init__.py` and in `citation.cff` (use [semantic
   versioning](https://semver.org/))
@@ -254,14 +251,7 @@ rights on WAM2layers.
   new version, and add a new "Unreleased" header above
 - Review and merge the release branch
 - [Make a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
-- Make sure to pull the latest changes to main in your local copy of the repo.
-- Publish to PyPI. In your terminal, in the base path of the repository, type:
-
-  ```bash
-  python -m build
-  twine upload dist/*
-  ```
-
+- Upon release, the Github Actions workflow for publishing will run. The publishing step requires manual approval, so go to the [workflow overview](https://github.com/WAM2layers/WAM2layers/actions) and approve the run. More extensive documentation on publishing is available [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).
 - Check that the new release is successfully rendered on Zenodo and PyPI.
 - Verify that you can install the new version with pip.
 


### PR DESCRIPTION
Closes #180 

- I followed the instructions on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- On PyPI I made the workflow file a "Trusted Publisher".
- I copied the workflow from https://github.com/eWaterCycle/ewatercycle-leakybucket where it ran successfully yesterday.