### PR TITLE
Split logged losses in boundary-transport and interior losses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed a bug in the profiler's `track_stability_correction` method ([#325](https://github.com/WAM2layers/WAM2layers/pull/325)).
+- Log message about "lost moisture" no longer includes boundary losses. Instead,
+  there is a separate log message for "boundary transport"
+  ([#343](https://github.com/WAM2layers/WAM2layers/pull/343))
 
 ### Changed
 - The workflow tests use a temporary directory managed by pytest and the user's operating system, to avoid the `/tmp` folder polluting the workspace ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).


### PR DESCRIPTION
Closes #340 

Now the (last) output of the sample run is:
```
2021-07-01 00:00:00 - Tracked moisture: 44.38%. Tagged in atmosphere: 3.63%. Boundary transport: 52.00%. Lost moisture: 0.00%. Gained moisture: 0.00%. Tagging closure: 100.00%. Time since start: 248.96s, RAM: 63.20 MB
2021-07-01 00:00:00 - Writing output to file /home/peter/wam2layers/floodcase_202107/output_data/backtrack_2021-07-01T00-00.nc
Experiment complete.
```