### PR TITLE
Add --version option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Adopted [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) as version support policy ([#333](https://github.com/WAM2layers/WAM2layers/pull/333)).
 - The output files now contain many attributes for easier interpretation ([#334](https://github.com/WAM2layers/WAM2layers/pull/334)).
 - Publishing of the package to the Python Package Index ([PyPI](https://pypi.org/)) is now automated with a Github Actions workflow ([#342](https://github.com/WAM2layers/WAM2layers/pull/342)).
+- You can now view the version of wam2layers by running `wam2layers --version` ([#352](https://github.com/WAM2layers/WAM2layers/pull/352)).
 
 ### Removed
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -32,6 +32,9 @@ interace (CLI), much like pip, conda, git, cdo, et cetera. It looks like this:
 wam2layers --help
 wam2layers track --help
 
+# Display the version of wam2layers you are using:
+wam2layers --version
+
 # Preprocess data (you need to have downloaded the data)
 wam2layers preprocess era5 floodcase_202107.yaml
 

--- a/src/wam2layers/cli.py
+++ b/src/wam2layers/cli.py
@@ -11,9 +11,11 @@ import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
+import sys
 
 import click
 
+from wam2layers import __version__
 from wam2layers.analysis import visualization
 from wam2layers.config import Config
 from wam2layers.preprocessing.era5 import prep_experiment
@@ -51,7 +53,17 @@ def _copy_config_yaml(yaml_path, target_path):
     shutil.copy(yaml_path, target_path)
 
 
+def get_wam_version():
+    """Get the version of WAM2layers"""
+    pkg_dir = Path(__file__).parent.absolute()
+    return (
+        f"wam2layers {__version__} from {pkg_dir} "
+        f"(python {sys.version_info.major}.{sys.version_info.minor})"
+    )
+
+
 @click.group()
+@click.version_option(message=get_wam_version())
 def cli():
     """Command line interface to WAM2layers."""
     pass


### PR DESCRIPTION
Modeled after pip: https://github.com/pypa/pip/blob/02ad0f3ffd278aa0a856cb9d80e0425d36838d1a/src/pip/_internal/utils/misc.py#L76

To test, do:
`wam2layers --version`

This should display the version, along with where it was installed and the python version (useful for debugging).

We could consider adding this to the issue template