### PR TITLE
Bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
 - Log message about "lost moisture" no longer includes boundary losses. Instead,
   there is a separate log message for "boundary transport"
   ([#343](https://github.com/WAM2layers/WAM2layers/pull/343))
+- Fixed a bug in the calculation of losses and gains for backtrack, where the moisture was compared to the wrong reference state ([#355](https://github.com/WAM2layers/WAM2layers/pull/355)).
+- The calculated gains are now absolute fields instead of relative to the reference field ([#355](https://github.com/WAM2layers/WAM2layers/pull/355)).
 
 ### Changed
 - The workflow tests use a temporary directory managed by pytest and the user's operating system, to avoid the `/tmp` folder polluting the workspace ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).

--- a/src/wam2layers/preprocessing/shared.py
+++ b/src/wam2layers/preprocessing/shared.py
@@ -287,6 +287,18 @@ def accumulation_to_flux(data, input_frequency):
     return fluxdata
 
 
+def get_boundary(field, periodic=False):
+    """Return a mask with 1 along the boundary and 0 in the interior."""
+    boundary = xr.ones_like(field, dtype=bool)
+    # Mask interior
+    if periodic:
+        boundary[1:-1, 0] = 0
+    else:
+        boundary[1:-1, 1:-1] = 0
+
+    return boundary
+
+
 def stagger_x(f):
     """Interpolate f to the grid cell interfaces.
 

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -26,7 +26,7 @@ from wam2layers.tracking.io import (
     write_output,
 )
 from wam2layers.tracking.shared import initialize_tagging_region, initialize_time
-from wam2layers.utils.profiling import ProgressTracker, warn_about_gains
+from wam2layers.utils.profiling import ProgressTracker
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,6 @@ def backtrack(
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)
-    warn_about_gains(gains_lower, gains_upper)
 
     # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
     overshoot_lower = np.maximum(0, s_track_lower - S0["s_lower"])

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -79,9 +79,8 @@ def backtrack(
     )
 
     # account for negative storages that are set to zero: "numerically gained water"
-    # TODO: why divide by S1/S0? I think it should be absolute values
-    gains_lower = np.where(s_track_lower < 0, s_track_lower / S0["s_lower"], 0)
-    gains_upper = np.where(s_track_upper < 0, s_track_upper / S0["s_upper"], 0)
+    gains_lower = np.where(s_track_lower < 0, s_track_lower, 0)  # TODO make positive?
+    gains_upper = np.where(s_track_upper < 0, s_track_upper, 0)
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -79,8 +79,8 @@ def backtrack(
     )
 
     # account for negative storages that are set to zero: "numerically gained water"
-    gains_lower = np.where(s_track_lower < 0, s_track_lower, 0)  # TODO make positive?
-    gains_upper = np.where(s_track_upper < 0, s_track_upper, 0)
+    gains_lower = np.where(s_track_lower < 0, -s_track_lower, 0)
+    gains_upper = np.where(s_track_upper < 0, -s_track_upper, 0)
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -79,18 +79,18 @@ def backtrack(
         + tagging_mask * precip * s_upper / (s_upper + s_lower)
     )
 
+    # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
+    overshoot_lower = np.maximum(0, s_track_lower - S0["s_lower"])
+    overshoot_upper = np.maximum(0, s_track_upper - S0["s_upper"])
+    s_track_lower = s_track_lower - overshoot_lower + overshoot_upper
+    s_track_upper = s_track_upper - overshoot_upper + overshoot_lower
+
     # account for negative storages that are set to zero: "numerically gained water"
     gains_lower = np.where(s_track_lower < 0, -s_track_lower, 0)
     gains_upper = np.where(s_track_upper < 0, -s_track_upper, 0)
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)
-
-    # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
-    overshoot_lower = np.maximum(0, s_track_lower - S0["s_lower"])
-    overshoot_upper = np.maximum(0, s_track_upper - S0["s_upper"])
-    s_track_lower = s_track_lower - overshoot_lower + overshoot_upper
-    s_track_upper = s_track_upper - overshoot_upper + overshoot_lower
 
     # At this point any of the storages could still be overfull, thus stabilize and assigns losses
     losses_lower = np.maximum(0, s_track_lower - S0["s_lower"])

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -25,7 +25,7 @@ from wam2layers.tracking.io import (
     write_output,
 )
 from wam2layers.tracking.shared import initialize_tagging_region, initialize_time
-from wam2layers.utils.profiling import ProgressTracker
+from wam2layers.utils.profiling import ProgressTracker, check_for_gains
 
 logger = logging.getLogger(__name__)
 
@@ -68,14 +68,6 @@ def backtrack(
         + tagging_mask * precip * s_lower / (s_upper + s_lower)
         - evap * s_track_relative_lower
     )
-    s_track_negative_lower = np.where(
-        s_track_lower < 0, s_track_lower / S1["s_lower"], 0
-    )
-    if np.any(s_track_negative_lower < -1e-5):
-        logger.warn(
-            f"""Negative values encountered in s_track_lower. . Check the gains output variable for details."""
-        )
-    s_track_lower = np.maximum(s_track_lower, 0)
 
     s_track_upper += config.timestep * (
         +horizontal_advection(s_track_relative_upper, -fx_upper, -fy_upper, bc)
@@ -85,54 +77,47 @@ def backtrack(
         )
         + tagging_mask * precip * s_upper / (s_upper + s_lower)
     )
-    s_track_negative_upper = np.where(
-        s_track_upper < 0, s_track_upper / S1["s_upper"], 0
-    )
-    if np.any(s_track_negative_upper < -1e-5):
-        logger.warn(
-            f"""Negative values encountered in s_track_upper. Check the gains output variable for details."""
-        )
-    s_track_upper = np.maximum(s_track_upper, 0)
 
     # account for negative storages that are set to zero: "numerically gained water"
-    gains = np.abs(s_track_negative_lower + s_track_negative_upper)
+    s_track_lower, gains_lower = check_for_gains(s_track_lower, reference=S1["s_lower"])
+    s_track_upper, gains_upper = check_for_gains(s_track_upper, reference=S1["s_upper"])
+    gains = np.abs(gains_lower + gains_upper)
 
     # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
-    # TODO build in logging for lost moisture
     overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])
     overshoot_upper = np.maximum(0, s_track_upper - S1["s_upper"])
     s_track_lower = s_track_lower - overshoot_lower + overshoot_upper
     s_track_upper = s_track_upper - overshoot_upper + overshoot_lower
-    # at this point any of the storages could still be overfull, thus stabilize and assigns losses:
+
+    # At this point any of the storages could still be overfull, thus stabilize and assigns losses
     losses_lower = np.maximum(0, s_track_lower - S1["s_lower"])
     losses_upper = np.maximum(0, s_track_upper - S1["s_upper"])
     losses = losses_lower + losses_upper
     s_track_lower = np.minimum(s_track_lower, S1["s_lower"])
     s_track_upper = np.minimum(s_track_upper, S1["s_upper"])
 
-    # Update output fields
-    output["e_track"] += evap * s_track_relative_lower * config.timestep
-    output["losses"] += losses
-    output["gains"] += gains
-
-    # Bookkeep boundary losses as "tracked moisture at grid edges"
-    output["losses"][0, :] += (s_track_upper + s_track_lower)[0, :]
-    output["losses"][-1, :] += (s_track_upper + s_track_lower)[-1, :]
+    # Bookkeep boundary transport as "lost moisture at grid edges"
+    losses[0, :] += (s_track_upper + s_track_lower)[0, :]
+    losses[-1, :] += (s_track_upper + s_track_lower)[-1, :]
     s_track_upper[0, :] = 0
     s_track_upper[-1, :] = 0
     s_track_lower[0, :] = 0
     s_track_lower[-1, :] = 0
-    if config.periodic_boundary is False:  # bookkeep west and east losses
-        output["losses"][:, 0] += (s_track_upper + s_track_lower)[:, 0]
-        output["losses"][:, -1] += (s_track_upper + s_track_lower)[:, -1]
+    if config.periodic_boundary is False:  # bookkeep west and east transport
+        losses[:, 0] += (s_track_upper + s_track_lower)[:, 0]
+        losses[:, -1] += (s_track_upper + s_track_lower)[:, -1]
         s_track_upper[:, 0] = 0
         s_track_upper[:, -1] = 0
         s_track_lower[:, 0] = 0
         s_track_lower[:, -1] = 0
 
+    # Update output fields
+    output["tagged_precip"] += tagging_mask * precip * config.timestep
+    output["e_track"] += evap * s_track_relative_lower * config.timestep
     output["s_track_lower_restart"].values = s_track_lower
     output["s_track_upper_restart"].values = s_track_upper
-    output["tagged_precip"] += tagging_mask * precip * config.timestep
+    output["losses"] += losses
+    output["gains"] += gains
 
 
 def initialize(config_file):

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 def backtrack(
     F,
     S1,
-    S0,  # TODO: why is this not used but both are used in forwardtrack?
+    S0,
     tagging_mask,
     output,
     config,
@@ -80,22 +80,22 @@ def backtrack(
 
     # account for negative storages that are set to zero: "numerically gained water"
     # TODO: reference should be S0?
-    s_track_lower, gains_lower = check_for_gains(s_track_lower, reference=S1["s_lower"])
-    s_track_upper, gains_upper = check_for_gains(s_track_upper, reference=S1["s_upper"])
+    s_track_lower, gains_lower = check_for_gains(s_track_lower, reference=S0["s_lower"])
+    s_track_upper, gains_upper = check_for_gains(s_track_upper, reference=S0["s_upper"])
     gains = np.abs(gains_lower + gains_upper)
 
     # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
-    overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])
-    overshoot_upper = np.maximum(0, s_track_upper - S1["s_upper"])
+    overshoot_lower = np.maximum(0, s_track_lower - S0["s_lower"])
+    overshoot_upper = np.maximum(0, s_track_upper - S0["s_upper"])
     s_track_lower = s_track_lower - overshoot_lower + overshoot_upper
     s_track_upper = s_track_upper - overshoot_upper + overshoot_lower
 
     # At this point any of the storages could still be overfull, thus stabilize and assigns losses
-    losses_lower = np.maximum(0, s_track_lower - S1["s_lower"])
-    losses_upper = np.maximum(0, s_track_upper - S1["s_upper"])
+    losses_lower = np.maximum(0, s_track_lower - S0["s_lower"])
+    losses_upper = np.maximum(0, s_track_upper - S0["s_upper"])
     losses = losses_lower + losses_upper
-    s_track_lower = np.minimum(s_track_lower, S1["s_lower"])
-    s_track_upper = np.minimum(s_track_upper, S1["s_upper"])
+    s_track_lower = np.minimum(s_track_lower, S0["s_lower"])
+    s_track_upper = np.minimum(s_track_upper, S0["s_upper"])
 
     # Bookkeep boundary transport as "lost moisture at grid edges"
     losses[0, :] += (s_track_upper + s_track_lower)[0, :]

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -79,6 +79,7 @@ def backtrack(
     )
 
     # account for negative storages that are set to zero: "numerically gained water"
+    # TODO: reference should be S0?
     s_track_lower, gains_lower = check_for_gains(s_track_lower, reference=S1["s_lower"])
     s_track_upper, gains_upper = check_for_gains(s_track_upper, reference=S1["s_upper"])
     gains = np.abs(gains_lower + gains_upper)

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -80,9 +80,8 @@ def forwardtrack(
     )
 
     # account for negative storages that are set to zero: "numerically gained water"
-    # TODO: why divide by S1? I think it should be absolute values
-    gains_lower = np.where(s_track_lower < 0, s_track_lower / S1["s_lower"], 0)
-    gains_upper = np.where(s_track_upper < 0, s_track_upper / S1["s_upper"], 0)
+    gains_lower = np.where(s_track_lower < 0, s_track_lower, 0)
+    gains_upper = np.where(s_track_upper < 0, s_track_upper, 0)
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -80,8 +80,8 @@ def forwardtrack(
     )
 
     # account for negative storages that are set to zero: "numerically gained water"
-    gains_lower = np.where(s_track_lower < 0, s_track_lower, 0)
-    gains_upper = np.where(s_track_upper < 0, s_track_upper, 0)
+    gains_lower = np.where(s_track_lower < 0, -s_track_lower, 0)
+    gains_upper = np.where(s_track_upper < 0, -s_track_upper, 0)
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -25,7 +25,7 @@ from wam2layers.tracking.io import (
     write_output,
 )
 from wam2layers.tracking.shared import initialize_tagging_region, initialize_time
-from wam2layers.utils.profiling import ProgressTracker, check_for_gains
+from wam2layers.utils.profiling import ProgressTracker, warn_about_gains
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +80,13 @@ def forwardtrack(
     )
 
     # account for negative storages that are set to zero: "numerically gained water"
-    s_track_lower, gains_lower = check_for_gains(s_track_lower, reference=S1["s_lower"])
-    s_track_upper, gains_upper = check_for_gains(s_track_upper, reference=S1["s_upper"])
+    # TODO: why divide by S1? I think it should be absolute values
+    gains_lower = np.where(s_track_lower < 0, s_track_lower / S1["s_lower"], 0)
+    gains_upper = np.where(s_track_upper < 0, s_track_upper / S1["s_upper"], 0)
     gains = np.abs(gains_lower + gains_upper)
+    s_track_lower = np.maximum(s_track_lower, 0)
+    s_track_upper = np.maximum(s_track_upper, 0)
+    warn_about_gains(gains_lower, gains_upper)
 
     # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
     overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -26,7 +26,7 @@ from wam2layers.tracking.io import (
     write_output,
 )
 from wam2layers.tracking.shared import initialize_tagging_region, initialize_time
-from wam2layers.utils.profiling import ProgressTracker, warn_about_gains
+from wam2layers.utils.profiling import ProgressTracker
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,6 @@ def forwardtrack(
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)
-    warn_about_gains(gains_lower, gains_upper)
 
     # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
     overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -80,18 +80,18 @@ def forwardtrack(
         - precip_upper * s_track_relative_upper
     )
 
+    # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
+    overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])
+    overshoot_upper = np.maximum(0, s_track_upper - S1["s_upper"])
+    s_track_lower = s_track_lower - overshoot_lower + overshoot_upper
+    s_track_upper = s_track_upper - overshoot_upper + overshoot_lower
+
     # account for negative storages that are set to zero: "numerically gained water"
     gains_lower = np.where(s_track_lower < 0, -s_track_lower, 0)
     gains_upper = np.where(s_track_upper < 0, -s_track_upper, 0)
     gains = np.abs(gains_lower + gains_upper)
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)
-
-    # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
-    overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])
-    overshoot_upper = np.maximum(0, s_track_upper - S1["s_upper"])
-    s_track_lower = s_track_lower - overshoot_lower + overshoot_upper
-    s_track_upper = s_track_upper - overshoot_upper + overshoot_lower
 
     # at this point any of the storages could still be overfull, thus stabilize and assigns losses:
     losses_lower = np.maximum(0, s_track_lower - S1["s_lower"])

--- a/src/wam2layers/utils/profiling.py
+++ b/src/wam2layers/utils/profiling.py
@@ -13,21 +13,17 @@ logger = logging.getLogger(__name__)
 # TODO: this is becoming more of a "checking/logging module than a profiler"
 
 
-def check_for_gains(field, reference):
-    """Check whether a given (moisture) field has negative values and remove them.
+def warn_about_gains(*arrays):
+    """Check whether a given (moisture) field has negative values.
 
     Warn if the negative values are excessive
     """
-    # TODO: why divide by a reference? Perhaps you meant to subtract?
-    gains = np.where(field < 0, field / reference, 0)
-
-    if np.any(gains < -1e-5):
-        logger.warn(
-            "Negative values encountered tracked moisture. Check the gains output variable for details."
-        )
-
-    corrected_field = np.maximum(field, 0)
-    return corrected_field, gains
+    for array in arrays:
+        if np.any(array < -1e-5):
+            logger.warning(
+                "Negative values encountered tracked moisture. "
+                "Check the gains output variable for details."
+            )
 
 
 class Profiler:

--- a/src/wam2layers/utils/profiling.py
+++ b/src/wam2layers/utils/profiling.py
@@ -1,6 +1,7 @@
 import logging
 import time
 
+import numpy as np
 import pandas as pd
 import psutil
 import xarray as xr
@@ -8,6 +9,25 @@ import xarray as xr
 from wam2layers.config import Config
 
 logger = logging.getLogger(__name__)
+
+# TODO: this is becoming more of a "checking/logging module than a profiler"
+
+
+def check_for_gains(field, reference):
+    """Check whether a given (moisture) field has negative values and remove them.
+
+    Warn if the negative values are excessive
+    """
+    # TODO: why divide by a reference? Perhaps you meant to subtract?
+    gains = np.where(field < 0, field / reference, 0)
+
+    if np.any(gains < -1e-5):
+        logger.warn(
+            "Negative values encountered tracked moisture. Check the gains output variable for details."
+        )
+
+    corrected_field = np.maximum(field, 0)
+    return corrected_field, gains
 
 
 class Profiler:

--- a/src/wam2layers/utils/profiling.py
+++ b/src/wam2layers/utils/profiling.py
@@ -10,21 +10,6 @@ from wam2layers.config import Config
 
 logger = logging.getLogger(__name__)
 
-# TODO: this is becoming more of a "checking/logging module than a profiler"
-
-
-def warn_about_gains(*arrays):
-    """Check whether a given (moisture) field has negative values.
-
-    Warn if the negative values are excessive
-    """
-    for array in arrays:
-        if np.any(array < -1e-5):
-            logger.warning(
-                "Negative values encountered tracked moisture. "
-                "Check the gains output variable for details."
-            )
-
 
 class Profiler:
     def __init__(self):

--- a/src/wam2layers/utils/profiling.py
+++ b/src/wam2layers/utils/profiling.py
@@ -96,7 +96,7 @@ class ProgressTracker:
             tracked_percentage
             + in_atmos_percentage
             + lost_percentage
-            - gained_percentage
+            + gained_percentage
             + boundary_percentage
         )
 


### PR DESCRIPTION
This PR isolates some commits from #349 concerning the bookkeeping of the tracking closure. Refs #347

* Reference state for backtracked is changed from `S1` to `S0`, i.e. the total moisture in the grid cell at the end of the timestep
* Gains are calculated as absolute fields instead of relative to the total moisture
* Gains are set to be positive (up for debate, but should be consistent with budget calcuation in log message)
* Warning about gains is moved to a separate utility function such that the tracking code is easier to read
* Bookkeeping and output writing are separated more clearly in the code.

Open questions (@ruudvdent): 
* Why not calculate the gains *after* redistributing unaccounted moisture between upper and lower?