### PR TITLE
Bugfix periodic boundary

### DIFF
--- a/src/wam2layers/tracking/core.py
+++ b/src/wam2layers/tracking/core.py
@@ -101,7 +101,7 @@ def horizontal_advection(s, u, v, periodic_x=False) -> np.ndarray:
     # Donor cell upwind scheme (2 directions seperately)
     uq = np.where(up > 0, up * qp[inner, west], up * qp[inner, east])  # [M, N+1]
 
-    vq = np.where(vp > 0, vp * qp[south, inner], vp * qp[north, inner])  # [M, N+2]
+    vq = np.where(vp > 0, vp * qp[south, inner], vp * qp[north, inner])  # [M+1, N]
 
     adv_x = uq[:, west] - uq[:, east]  # [M, N]
     adv_y = vq[south, :] - vq[north, :]  # [M, N]

--- a/src/wam2layers/utils/grid.py
+++ b/src/wam2layers/utils/grid.py
@@ -61,7 +61,7 @@ def get_boundary(field, periodic=False):
     boundary = xr.ones_like(field, dtype=bool)
     # Mask interior
     if periodic:
-        boundary[1:-1, 0] = 0
+        boundary[1:-1, :] = 0
     else:
         boundary[1:-1, 1:-1] = 0
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,32 @@
+import numpy as np
+import xarray as xr
+
+from wam2layers.utils.grid import get_boundary
+
+
+def test_get_boundary():
+    a = np.arange(12).reshape(3, 4)
+    a_xr = xr.DataArray(a)
+    result = get_boundary(a_xr)
+    expected = np.array(
+        [
+            [True, True, True, True],
+            [True, False, False, True],
+            [True, True, True, True],
+        ]
+    )
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_get_boundary_periodic():
+    a = np.arange(12).reshape(3, 4)
+    a_xr = xr.DataArray(a)
+    result = get_boundary(a_xr, periodic=True)
+    expected = np.array(
+        [
+            [True, True, True, True],
+            [False, False, False, False],
+            [True, True, True, True],
+        ]
+    )
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Fixes #378 

I think I found the bug described in #378. With this fix, after one day of tracking, I get:

```
2022-02-27 00:00:00 - Tracked moisture: 5.50%. Tagged in atmosphere: 94.24%. 
    Boundary transport: 0.00%. Lost moisture: 0.26%. Gained moisture: 0.00%. Tagging closure: 100.00%. 
```

So still some lost moisture, but not the 100% that we saw before.