### PR TITLE
In simulations with periodic boundaries, stagger the flux to the exterior edges as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+
 - Windows instruction to the installation guide ([#392](https://github.com/WAM2layers/WAM2layers/pull/392)).
 - support for preprocessing CMIP data ([#401](https://github.com/WAM2layers/WAM2layers/pull/401)).
 - experimental support for parallel preprocessing ([#401](https://github.com/WAM2layers/WAM2layers/pull/401)).
 - config file documentation expanded ([#398](https://github.com/WAM2layers/WAM2layers/pull/398)).
+
+### Fixed
+
+- In simulations with periodic boundaries, stagger the flux to the exterior edges as well ([#426](https://github.com/WAM2layers/WAM2layers/pull/426)).
 
 ## Release v3.1.0 (2024-06-21)
 
@@ -54,10 +59,11 @@ All notable changes to this project will be documented in this file.
 - The calculated gains are now absolute fields instead of relative to the reference field ([#355](https://github.com/WAM2layers/WAM2layers/pull/355)).
 
 ### Changed
+
 - The workflow tests use a temporary directory managed by pytest and the user's operating system, to avoid the `/tmp` folder polluting the workspace ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - The workflow tests now make extensive use of pytest's [fixtures](https://docs.pytest.org/en/8.0.x/explanation/fixtures.html), which will make future test writing easier ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
 - The `kvf` parameter can now be a floating point number instead of an integer ([#320](https://github.com/WAM2layers/WAM2layers/pull/320)).
-- The stability correction warning will now occur only when 10% more of the grid is corrected compared to last warning, or the correction factor is 10% stronger  ([#332](https://github.com/WAM2layers/WAM2layers/pull/332)).
+- The stability correction warning will now occur only when 10% more of the grid is corrected compared to last warning, or the correction factor is 10% stronger ([#332](https://github.com/WAM2layers/WAM2layers/pull/332)).
 - The output files now contain a time dimension (incl. the coordinate) ([#334](https://github.com/WAM2layers/WAM2layers/pull/334)).
 - The package version is now defined in `src/wam2layers/__init__.py` ([#334](https://github.com/WAM2layers/WAM2layers/pull/334)).
 - The command line interface for tracking has changed. Tracking experiments are now started by doing `wam2layers track config.yml`. The tracking direction is retrieved from the new configuration entry "tracking_direction" ([#338](https://github.com/WAM2layers/WAM2layers/pull/338)).
@@ -91,9 +97,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - The "analyse output" command now excludes the first timestep when it looks for output files, as it is usually not present in backtrack output ([#266](https://github.com/WAM2layers/WAM2layers/pull/266)).
-- A long-existing bug in the calculation of vertical fluxes, effectively changing the direction of the vertical flux ([#274](https://github.com/WAM2layers/WAM2layers/pull/274)). Also use the *new* state in the error correction term `S_1 / S_T * err_T`
+- A long-existing bug in the calculation of vertical fluxes, effectively changing the direction of the vertical flux ([#274](https://github.com/WAM2layers/WAM2layers/pull/274)). Also use the _new_ state in the error correction term `S_1 / S_T * err_T`
 - Log files are now saved to the output path, instead of the current working directory ([#291](https://github.com/WAM2layers/WAM2layers/pull/291))
-
 
 ### Changed
 
@@ -121,7 +126,6 @@ All notable changes to this project will be documented in this file.
 - last time step is outputted (but with name of 00.10)
 - Output filenames now also include hours and minutes
 
-
 ## Release v3.0.0-beta.4 (2023-04-21)
 
 ### Added
@@ -141,10 +145,13 @@ All notable changes to this project will be documented in this file.
 ## Release v3.0.0-beta.3 (2022-12-02)
 
 ### Fixed (patch version, bugs)
+
 - n/a
 
 ### Added (minor version only)
+
 Some highlights:
+
 - Chunking using xarray the preprocessed data
 - Visualizing output data
 - Allowing global input data to read
@@ -152,4 +159,5 @@ Some highlights:
 - From double to single precision
 
 ### Changed and removed (major version only)
+
 - n/a

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -76,7 +76,7 @@ def backtrack(
     )
 
     # Remove boundary transport from s_track and bookkeep losses
-    boundary = get_boundary(losses, periodic=config.periodic_boundary)
+    boundary = get_boundary(s_track_upper, periodic=config.periodic_boundary)
     losses = xr.where(boundary, (s_track_upper + s_track_lower), 0)
     s_track_upper = xr.where(boundary, 0, s_track_upper)
     s_track_lower = xr.where(boundary, 0, s_track_lower)

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -77,7 +77,7 @@ def backtrack(
 
     # Remove boundary transport from s_track and bookkeep losses
     boundary = get_boundary(s_track_upper, periodic=config.periodic_boundary)
-    losses = xr.where(boundary, (s_track_upper + s_track_lower), 0)
+    losses = np.where(boundary, (s_track_upper + s_track_lower), 0)
     s_track_upper = xr.where(boundary, 0, s_track_upper)
     s_track_lower = xr.where(boundary, 0, s_track_lower)
 

--- a/src/wam2layers/tracking/core.py
+++ b/src/wam2layers/tracking/core.py
@@ -80,7 +80,7 @@ def horizontal_advection(s, u, v, periodic_x=False) -> np.ndarray:
         vp = pad_y_zero(v)  # [M-1, N] -> [M+1, N]
     else:
         sp = pad_xy_zero(s)  # [M, N] -> [M+2, N+2]
-        up = pad_xy_zero(u)  # [M-2, N-1] -> [M, N-1]
+        up = pad_xy_zero(u)  # [M-2, N-1] -> [M, N+1]
         vp = pad_xy_zero(v)  # [M-1, N-2] -> [M+1, N]
 
     west = np.s_[:-1]

--- a/src/wam2layers/tracking/core.py
+++ b/src/wam2layers/tracking/core.py
@@ -5,7 +5,7 @@ import numpy as np
 from wam2layers.config import Config
 from wam2layers.utils.profiling import ProgressTracker
 
-# Functions to pad poundaries of arrays
+# Functions to pad boundaries of arrays
 pad_x_wrap = partial(np.pad, pad_width=((0, 0), (1, 1)), mode="wrap")
 pad_y_zero = partial(
     np.pad, pad_width=((1, 1), (0, 0)), mode="constant", constant_values=0
@@ -83,6 +83,7 @@ def horizontal_advection(s, u, v, periodic_x=False) -> np.ndarray:
         up = pad_xy_zero(u)  # [M-2, N-1] -> [M, N+1]
         vp = pad_xy_zero(v)  # [M-1, N-2] -> [M+1, N]
 
+    # Useful for indexing the arrays later on
     west = np.s_[:-1]
     east = np.s_[1:]
     south = np.s_[1:]
@@ -93,6 +94,7 @@ def horizontal_advection(s, u, v, periodic_x=False) -> np.ndarray:
     us = np.where(up > 0, up * sp[inner, west], up * sp[inner, east])  # [M, N+1]
     vs = np.where(vp > 0, vp * sp[south, inner], vp * sp[north, inner])  # [M+1, N]
 
+    # Combine advection from all surrounding cells into one
     adv_x = us[:, west] - us[:, east]  # [M, N]
     adv_y = vs[south, :] - vs[north, :]  # [M, N]
 

--- a/src/wam2layers/tracking/core.py
+++ b/src/wam2layers/tracking/core.py
@@ -75,11 +75,11 @@ def horizontal_advection(s, u, v, periodic_x=False) -> np.ndarray:
     """
     # Pad boundaries with ghost cells
     if periodic_x:
-        qp = pad_y_zero(pad_x_wrap(q))  # [M, N] -> [M+2, N+2]
+        sp = pad_y_zero(pad_x_wrap(s))  # [M, N] -> [M+2, N+2]
         up = pad_y_zero(u)  # [M-2, N+1] -> [M, N+1]
         vp = pad_y_zero(v)  # [M-1, N] -> [M+1, N]
     else:
-        qp = pad_xy_zero(q)  # [M, N] -> [M+2, N+2]
+        sp = pad_xy_zero(s)  # [M, N] -> [M+2, N+2]
         up = pad_xy_zero(u)  # [M-2, N-1] -> [M, N-1]
         vp = pad_xy_zero(v)  # [M-1, N-2] -> [M+1, N]
 
@@ -90,11 +90,11 @@ def horizontal_advection(s, u, v, periodic_x=False) -> np.ndarray:
     inner = np.s_[1:-1]
 
     # Donor cell upwind scheme (2 directions seperately)
-    uq = np.where(up > 0, up * qp[inner, west], up * qp[inner, east])  # [M, N+1]
-    vq = np.where(vp > 0, vp * qp[south, inner], vp * qp[north, inner])  # [M+1, N]
+    us = np.where(up > 0, up * sp[inner, west], up * sp[inner, east])  # [M, N+1]
+    vs = np.where(vp > 0, vp * sp[south, inner], vp * sp[north, inner])  # [M+1, N]
 
-    adv_x = uq[:, west] - uq[:, east]  # [M, N]
-    adv_y = vq[south, :] - vq[north, :]  # [M, N]
+    adv_x = us[:, west] - us[:, east]  # [M, N]
+    adv_y = vs[south, :] - vs[north, :]  # [M, N]
 
     return adv_x + adv_y  # [M, N]
 

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -76,6 +76,12 @@ def forwardtrack(
         - precip_upper * s_track_relative_upper
     )
 
+    # Remove boundary transport from s_track and bookkeep losses
+    boundary = get_boundary(s_track_upper, periodic=config.periodic_boundary)
+    losses = np.where(boundary, (s_track_upper + s_track_lower), 0)
+    s_track_upper = xr.where(boundary, 0, s_track_upper)
+    s_track_lower = xr.where(boundary, 0, s_track_lower)
+
     # lower and upper: redistribute unaccounted water that is otherwise lost from the sytem
     overshoot_lower = np.maximum(0, s_track_lower - S1["s_lower"])
     overshoot_upper = np.maximum(0, s_track_upper - S1["s_upper"])
@@ -92,15 +98,9 @@ def forwardtrack(
     # at this point any of the storages could still be overfull, thus stabilize and assigns losses:
     losses_lower = np.maximum(0, s_track_lower - S1["s_lower"])
     losses_upper = np.maximum(0, s_track_upper - S1["s_upper"])
-    losses = losses_lower + losses_upper
+    losses += losses_lower + losses_upper
     s_track_lower = np.minimum(s_track_lower, S1["s_lower"])
     s_track_upper = np.minimum(s_track_upper, S1["s_upper"])
-
-    # Bookkeep boundary transport as "lost moisture at grid edges"
-    boundary = get_boundary(losses, periodic=config.periodic_boundary)
-    losses += xr.where(boundary, (s_track_upper + s_track_lower), 0)
-    s_track_upper = xr.where(boundary, 0, s_track_upper)
-    s_track_lower = xr.where(boundary, 0, s_track_lower)
 
     # Update output fields
     output["tagged_evap"] += region * evap * config.timestep

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -95,7 +95,7 @@ def forwardtrack(
     s_track_lower = np.maximum(s_track_lower, 0)
     s_track_upper = np.maximum(s_track_upper, 0)
 
-    # at this point any of the storages could still be overfull, thus stabilize and assigns losses:
+    # At this point the storages could still be overfull internally, thus stabilize and assign internal losses
     losses_lower = np.maximum(0, s_track_lower - S1["s_lower"])
     losses_upper = np.maximum(0, s_track_upper - S1["s_upper"])
     losses += losses_lower + losses_upper

--- a/src/wam2layers/utils/grid.py
+++ b/src/wam2layers/utils/grid.py
@@ -27,7 +27,7 @@ def stagger_x(fx, periodic_x=False):
     return fx_new[1:-1, :]
 
 
-def stagger_y(fy, periodic_x=True):
+def stagger_y(fy, periodic_x=False):
     """Interpolate fy to the grid cell interfaces.
     Only the values at the interior interfaces are returned
     Arguments:
@@ -35,9 +35,9 @@ def stagger_y(fy, periodic_x=True):
     Returns:
         2d array of shape [M-1, N-2] or [M-1, N] when periodic_x = True
     """
-    if not periodic_x:
-        return 0.5 * (fy[:-1, :] + fy[1:, :])[:, 1:-1]
-    return 0.5 * (fy[:-1, :] + fy[1:, :])
+    if periodic_x:
+        return 0.5 * (fy[:-1, :] + fy[1:, :])
+    return 0.5 * (fy[:-1, :] + fy[1:, :])[:, 1:-1]
 
 
 def get_grid_info(ds):

--- a/src/wam2layers/utils/grid.py
+++ b/src/wam2layers/utils/grid.py
@@ -4,26 +4,40 @@ import numpy as np
 import xarray as xr
 
 
-def stagger_x(f):
+def stagger_x(fx, periodic_x=False):
     """Interpolate f to the grid cell interfaces.
-    Only the values at the interior interfaces are returned
+
+    Only the values at the interior interfaces are returned, except when
+    periodic is True. In that case, the same value is inserted at both the east
+    and west interfaces.
+
     Arguments:
-        f: 2d array of shape [M, N]
+        fx: 2d array of shape [M, N]
     Returns:
-        2d array of shape [M-2, N-1]
+        2d array of shape [M-2, N-1] or [M-2, N+1] when periodic_x = True
     """
-    return 0.5 * (f[:, :-1] + f[:, 1:])[1:-1, :]
+    if not periodic_x:
+        return 0.5 * (fx[:, :-1] + fx[:, 1:])[1:-1, :]
+
+    ny, nx = fx.shape
+    fx_new = np.zeros((ny, nx + 1))
+    fx_new[:, 1:-1] = 0.5 * (fx[:, :-1] + fx[:, 1:])
+    fx_new[:, 0] = 0.5 * (fx[:, 0] + fx[:, -1])
+    fx_new[:, -1] = 0.5 * (fx[:, 0] + fx[:, -1])
+    return fx_new[1:-1, :]
 
 
-def stagger_y(f):
-    """Interpolate f to the grid cell interfaces.
+def stagger_y(fy, periodic_x=True):
+    """Interpolate fy to the grid cell interfaces.
     Only the values at the interior interfaces are returned
     Arguments:
-        f: 2d array of shape [M, N]
+        fy: 2d array of shape [M, N]
     Returns:
-        2d array of shape [M-1, N-2]
+        2d array of shape [M-1, N-2] or [M-1, N] when periodic_x = True
     """
-    return 0.5 * (f[:-1, :] + f[1:, :])[:, 1:-1]
+    if not periodic_x:
+        return 0.5 * (fy[:-1, :] + fy[1:, :])[:, 1:-1]
+    return 0.5 * (fy[:-1, :] + fy[1:, :])
 
 
 def get_grid_info(ds):

--- a/src/wam2layers/utils/grid.py
+++ b/src/wam2layers/utils/grid.py
@@ -72,7 +72,7 @@ def get_grid_info(ds):
 
 def get_boundary(field, periodic=False):
     """Return a mask with 1 along the boundary and 0 in the interior."""
-    boundary = xr.ones_like(field, dtype=bool)
+    boundary = np.ones_like(field, dtype=bool)
     # Mask interior
     if periodic:
         boundary[1:-1, :] = 0


### PR DESCRIPTION
In calculating the horizontal advection term, padding is added to boundaries.
For periodic boundaries, this led to erroneous behaviour, since the padded Fx values would correspond to the interior rather than exterior boundary. 

This fix changes the code as follows:

If boundaries are periodic:
- Fx staggering now includes the outer edge, which is interpolated between the first and last grid cells. That value is inserted both at the right and and the left end.
  Return shape is now [M-2, N-1] or [M-2, N+1] when periodic_x = True
- Fy staggering only on interior, but doesn't discard the outermost x-values
  Return shape is now [M-1, N-2] or [M-1, N] when periodic_x = True
- In the advection calculation, padding is applied differently when domain is periodic:
  - For u and v, only the southern and northern edges are padded.
  - For s, the behaviour is same as before: in the x-direction we pad with mode=wrap, i.e. leftmost value is inserted at the right and vice versa.

Should fix #424 
Might be related to https://github.com/WAM2layers/WAM2layers/discussions/225 as well