### PR TITLE
Fix for incorrect staggering of periodic boundaries

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,11 +4,13 @@
 
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-20.04
   tools:
     python: "3.11"
-
 
 python:
    install:

--- a/src/wam2layers/tracking/backtrack.py
+++ b/src/wam2layers/tracking/backtrack.py
@@ -38,10 +38,10 @@ def backtrack(
     a, dy, dx = get_grid_info(F)
 
     # Unpack input data
-    fx_upper = stagger_x(F["fx_upper"].values)
-    fy_upper = stagger_y(F["fy_upper"].values)
-    fx_lower = stagger_x(F["fx_lower"].values)
-    fy_lower = stagger_y(F["fy_lower"].values)
+    fx_upper = stagger_x(F["fx_upper"].values, config.periodic_boundary)
+    fy_upper = stagger_y(F["fy_upper"].values, config.periodic_boundary)
+    fx_lower = stagger_x(F["fx_lower"].values, config.periodic_boundary)
+    fy_lower = stagger_y(F["fy_lower"].values, config.periodic_boundary)
     evap = F["evap"].values
     precip = F["precip"].values
     f_vert = F["f_vert"].values

--- a/src/wam2layers/tracking/forwardtrack.py
+++ b/src/wam2layers/tracking/forwardtrack.py
@@ -38,10 +38,10 @@ def forwardtrack(
     a, dy, dx = get_grid_info(F)
 
     # Unpack input data
-    fx_upper = stagger_x(F["fx_upper"].values)
-    fy_upper = stagger_y(F["fy_upper"].values)
-    fx_lower = stagger_x(F["fx_lower"].values)
-    fy_lower = stagger_y(F["fy_lower"].values)
+    fx_upper = stagger_x(F["fx_upper"].values, config.periodic_boundary)
+    fy_upper = stagger_y(F["fy_upper"].values, config.periodic_boundary)
+    fx_lower = stagger_x(F["fx_lower"].values, config.periodic_boundary)
+    fy_lower = stagger_y(F["fy_lower"].values, config.periodic_boundary)
     evap = F["evap"].values
     precip = F["precip"].values
     f_vert = F["f_vert"].values


### PR DESCRIPTION
fixes #442 

The `stagger` function was extended to behave differently for periodic boundaries in #426, but it appears I forgot to pass the corresponding input parameter during the call to `stagger`.

With this fix, global test data case works for me both in forward and backward mode. Haven't checked the output.