### PR TITLE
Fix frequency correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 - updated reference to WAM2layers v3 paper
 
+### Fixed
+- Invalid "correction" for deprecated frequencies in pandas which erroneously also changes monthly frequencies like MS to ms. ([#490](https://github.com/WAM2layers/WAM2layers/pull/490))
+
 ## Release v3.2.2 (2025-03-28)
 
 ### Fixed

--- a/src/wam2layers/config.py
+++ b/src/wam2layers/config.py
@@ -15,7 +15,11 @@ from pydantic import (
 )
 from typing_extensions import Annotated
 
-from wam2layers.utils.calendar import CfDateTime, cftime_from_iso
+from wam2layers.utils.calendar import (
+    CfDateTime,
+    cftime_from_iso,
+    fix_deprecated_frequency,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -317,8 +321,9 @@ class Config(BaseModel):
 
     """
 
-    input_frequency: str
+    input_frequency: Annotated[str, AfterValidator(fix_deprecated_frequency)]
     """Time frequency of the raw input data.
+
     This refers to the time frequency of the climate or weather model data
     data. Primarily used during the preprocessing, but the setting does carry
     over to the tracking as well.
@@ -349,7 +354,7 @@ class Config(BaseModel):
 
     """
 
-    output_frequency: str
+    output_frequency: Annotated[str, AfterValidator(fix_deprecated_frequency)]
     """Frequency at which to write output to file.
     TODO: clarify if this is used during preprocessing, tracking or both
 

--- a/src/wam2layers/utils/calendar.py
+++ b/src/wam2layers/utils/calendar.py
@@ -113,8 +113,6 @@ def round_cftime(
     date: CfDateTime, freq: str, how: Literal["nearest", "floor", "ceil"]
 ) -> CfDateTime:
     """Round a CF datetime index to a nearest frequency."""
-    freq = fix_deprecated_frequency(freq)
-
     if how == "nearest":
         return xr.CFTimeIndex([date], calendar=date.calendar).round(freq)[0]
     if how == "ceil":

--- a/tests/unit/test_frequency.py
+++ b/tests/unit/test_frequency.py
@@ -1,0 +1,59 @@
+import pytest
+
+from wam2layers.utils.calendar import fix_deprecated_frequency
+
+
+@pytest.mark.parametrize(
+    "freq,expected",
+    [
+        # Deprecated aliases (should be fixed)
+        ("H", "h"),
+        ("5H", "5h"),
+        ("BH", "bh"),
+        ("2BH", "2bh"),
+        ("CBH", "cbh"),
+        ("3CBH", "3cbh"),
+        ("T", "min"),
+        ("10T", "10min"),
+        ("S", "s"),
+        ("15S", "15s"),
+        ("L", "ms"),
+        ("20L", "20ms"),
+        ("U", "us"),
+        ("30U", "30us"),
+        ("N", "ns"),
+        ("40N", "40ns"),
+        # Valid aliases (should stay unchanged)
+        ("MS", "MS"),  # month start
+        ("BMS", "BMS"),  # business month start
+        ("QS", "QS"),  # quarter start
+        ("AS", "AS"),  # year start
+        ("W", "W"),  # week
+        ("D", "D"),  # day
+        ("min", "min"),  # already valid
+        ("ms", "ms"),  # already valid
+        ("us", "us"),  # already valid
+        ("ns", "ns"),  # already valid
+        # Edge cases
+        ("5min", "5min"),  # valid new alias
+        ("", ""),  # empty string
+        ("foobar", "foobar"),  # unknown alias, passthrough
+    ],
+)
+def test_fix_freq(freq, expected):
+    assert fix_deprecated_frequency(freq) == expected
+
+
+@pytest.mark.parametrize(
+    "freq,not_expected",
+    [
+        # Regression guards (make sure these do NOT change incorrectly)
+        ("MS", "ms"),  # month start must NOT become millisecond
+        ("BMS", "bms"),  # business month start must NOT be lowercased
+        ("QS", "qs"),  # quarter start must NOT be lowercased
+        ("AS", "as"),  # year start must NOT be lowercased
+    ],
+)
+def test_fix_freq_not_expected(freq, not_expected):
+    """Test that fix_freq does not rewrite valid aliases into wrong ones."""
+    assert fix_deprecated_frequency(freq) != not_expected


### PR DESCRIPTION
fixes #485 

- Use regex to find all deprecated frequency strings and update them to the new convention
- Immediately fix frequencies as part of parsing the config (using [pydantic field validators](https://docs.pydantic.dev/latest/concepts/validators/#using-the-annotated-pattern))
- Add tests to ensure the frequency fix works as expected