### PR TITLE
small user inflicted bug fix download_preprocessed

### DIFF
--- a/src/wam2layers/download_preprocessed.py
+++ b/src/wam2layers/download_preprocessed.py
@@ -108,6 +108,8 @@ def download_from_config(config_file: str, protocol="http", crop=True):
     if crop:
         bbox = str(cfg.tracking_domain)
         print(f"Tracking domain: {bbox}")
+        if bbox == "None":
+            bbox = None
     else:
         bbox = None
 


### PR DESCRIPTION
In download_preprocessed.py:
When filling in 'null' as the tracking domain, the code should not try to crop the input fields. With my python version (3.12.4 and yaml version 6.0.1), it reads it in as a string, which triggers the 'crop' functionality.
The added lines make sure that the string is converted to a NoneType.