### PR TITLE
version change

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
 


### PR DESCRIPTION
change read the docs build to 24.04 because 20.04 is deprecated
https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/